### PR TITLE
Replace variants with ColorPattern::Repeating(vec![ColorSequence])

### DIFF
--- a/gui/src/akai_mpd226_editor.rs
+++ b/gui/src/akai_mpd226_editor.rs
@@ -194,8 +194,13 @@ pub struct ColorMappingState {
 }
 impl Default for ColorMappingState {
     fn default() -> Self {
+        let pattern = ColorPattern::Repeating(vec![ColorSequence {
+            len: 64,
+            color: PadColor::Off,
+        }]);
+
         Self {
-            pattern: ColorPattern::Contiguous(PadColor::Off),
+            pattern,
             length: 64,
             starting_from_pad: 0,
         }
@@ -417,7 +422,7 @@ fn render_pad_patterns(ui: &mut Ui, ui_state: &mut UiState) {
 
         ui.add_space(32.0);
 
-        render_color_mapping(ui, ui_state);
+        render_off_color_mapping(ui, ui_state);
 
         ui.add_space(32.0);
 
@@ -577,24 +582,9 @@ fn render_note_mapping(ui: &mut Ui, ui_state: &mut UiState) {
     });
 }
 
-fn render_color_mapping(ui: &mut Ui, ui_state: &mut UiState) {
+fn render_off_color_mapping(ui: &mut Ui, ui_state: &mut UiState) {
     ui.vertical(|ui| {
         ui.label("Off Color Mapping");
-
-        ui.horizontal(|ui| {
-            let is_contiguous = matches!(
-                ui_state.off_color_mapping.pattern,
-                ColorPattern::Contiguous(_)
-            );
-            if ui.selectable_label(is_contiguous, "Contiguous").clicked() && !is_contiguous {
-                ui_state.off_color_mapping.pattern = ColorPattern::Contiguous(PadColor::Off);
-            }
-            if ui.selectable_label(!is_contiguous, "Grouped").clicked() && is_contiguous {
-                ui_state.off_color_mapping.pattern = ColorPattern::Grouped(vec![]);
-            }
-        });
-
-        ui.add_space(4.0);
 
         render_color_pattern_editor(ui, "off", &mut ui_state.off_color_mapping.pattern);
 
@@ -626,19 +616,6 @@ fn render_on_color_mapping(ui: &mut Ui, ui_state: &mut UiState) {
     ui.vertical(|ui| {
         ui.label("On Color Mapping");
 
-        ui.horizontal(|ui| {
-            let is_contiguous = matches!(
-                ui_state.on_color_mapping.pattern,
-                ColorPattern::Contiguous(_)
-            );
-            if ui.selectable_label(is_contiguous, "Contiguous").clicked() && !is_contiguous {
-                ui_state.on_color_mapping.pattern = ColorPattern::Contiguous(PadColor::Off);
-            }
-            if ui.selectable_label(!is_contiguous, "Grouped").clicked() && is_contiguous {
-                ui_state.on_color_mapping.pattern = ColorPattern::Grouped(vec![]);
-            }
-        });
-
         ui.add_space(4.0);
 
         render_color_pattern_editor(ui, "on", &mut ui_state.on_color_mapping.pattern);
@@ -669,19 +646,7 @@ fn render_on_color_mapping(ui: &mut Ui, ui_state: &mut UiState) {
 
 fn render_color_pattern_editor(ui: &mut Ui, id_prefix: &str, pattern: &mut ColorPattern) {
     match pattern {
-        ColorPattern::Contiguous(color) => {
-            ui.horizontal(|ui| {
-                ui.label("Color");
-                ComboBox::from_id_salt(format!("{}_color", id_prefix))
-                    .selected_text(color.to_string())
-                    .show_ui(ui, |ui| {
-                        for c in PadColor::iter() {
-                            ui.selectable_value(color, c, c.to_string());
-                        }
-                    });
-            });
-        }
-        ColorPattern::Grouped(sequences) => {
+        ColorPattern::Repeating(sequences) => {
             if ui.button("+ Add").clicked() {
                 sequences.push(ColorSequence {
                     len: 4,

--- a/midilab/src/manufacturer/akai/mpd226.rs
+++ b/midilab/src/manufacturer/akai/mpd226.rs
@@ -174,7 +174,7 @@ impl Default for Preset {
         pads.set_off_color_pattern(
             0,
             64,
-            ColorPattern::Grouped(vec![
+            ColorPattern::Repeating(vec![
                 ColorSequence {
                     len: 4,
                     color: PadColor::Red,
@@ -245,7 +245,7 @@ impl Default for Preset {
         pads.set_on_color_pattern(
             0,
             64,
-            ColorPattern::Grouped(vec![
+            ColorPattern::Repeating(vec![
                 ColorSequence {
                     len: 4,
                     color: PadColor::Green,
@@ -434,15 +434,13 @@ pub enum NotePattern {
 
 #[derive(Clone)]
 pub enum ColorPattern {
-    Contiguous(PadColor),
-    Grouped(Vec<ColorSequence>),
+    Repeating(Vec<ColorSequence>),
 }
 
 impl ColorPattern {
     pub fn color_at_index(&self, index: usize) -> PadColor {
         match self {
-            ColorPattern::Contiguous(color) => *color,
-            ColorPattern::Grouped(sequences) => {
+            ColorPattern::Repeating(sequences) => {
                 if sequences.is_empty() {
                     return PadColor::default();
                 }

--- a/midilab/src/manufacturer/akai/mpd226/repository.rs
+++ b/midilab/src/manufacturer/akai/mpd226/repository.rs
@@ -47,7 +47,7 @@ impl PadRepository {
         length: usize,
         pattern: ColorPattern,
     ) {
-        if matches!(&pattern, ColorPattern::Grouped(seqs) if seqs.is_empty()) {
+        if matches!(&pattern, ColorPattern::Repeating(seqs) if seqs.is_empty()) {
             return;
         }
 
@@ -66,7 +66,7 @@ impl PadRepository {
         length: usize,
         pattern: ColorPattern,
     ) {
-        if matches!(&pattern, ColorPattern::Grouped(seqs) if seqs.is_empty()) {
+        if matches!(&pattern, ColorPattern::Repeating(seqs) if seqs.is_empty()) {
             return;
         }
 
@@ -229,6 +229,7 @@ impl TryFrom<RawDials> for DialRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manufacturer::akai::mpd226::ColorSequence;
     use crate::manufacturer::akai::mpd226::control::value_kind::ActiveState;
     use crate::manufacturer::akai::mpd226::control::value_kind::DialKind;
     use crate::manufacturer::akai::mpd226::control::value_kind::FaderKind;
@@ -314,7 +315,14 @@ mod tests {
     fn test_pad_repository_set_off_color_pattern() {
         let mut repo = PadRepository::default();
 
-        repo.set_off_color_pattern(0, 16, ColorPattern::Contiguous(PadColor::Blue));
+        repo.set_off_color_pattern(
+            0,
+            16,
+            ColorPattern::Repeating(vec![ColorSequence {
+                len: 16,
+                color: PadColor::Blue,
+            }]),
+        );
 
         for i in 0..16 {
             assert_eq!(repo.pads[i].off_color, PadColor::Blue);
@@ -327,7 +335,14 @@ mod tests {
     fn test_pad_repository_set_off_color_pattern_with_offset() {
         let mut repo = PadRepository::default();
 
-        repo.set_off_color_pattern(8, 8, ColorPattern::Contiguous(PadColor::Red));
+        repo.set_off_color_pattern(
+            8,
+            8,
+            ColorPattern::Repeating(vec![ColorSequence {
+                len: 8,
+                color: PadColor::Red,
+            }]),
+        );
 
         for i in 0..8 {
             assert_eq!(repo.pads[i].off_color, PadColor::default());
@@ -342,7 +357,14 @@ mod tests {
     fn test_pad_repository_set_on_color_pattern() {
         let mut repo = PadRepository::default();
 
-        repo.set_on_color_pattern(0, 8, ColorPattern::Contiguous(PadColor::Green));
+        repo.set_on_color_pattern(
+            0,
+            8,
+            ColorPattern::Repeating(vec![ColorSequence {
+                len: 8,
+                color: PadColor::Green,
+            }]),
+        );
 
         for i in 0..8 {
             assert_eq!(repo.pads[i].on_color, PadColor::Green);
@@ -354,7 +376,14 @@ mod tests {
     fn test_pad_repository_apply_color_pattern_exceeds_total() {
         let mut repo = PadRepository::default();
 
-        repo.set_off_color_pattern(60, 10, ColorPattern::Contiguous(PadColor::Yellow));
+        repo.set_off_color_pattern(
+            60,
+            10,
+            ColorPattern::Repeating(vec![ColorSequence {
+                len: 10,
+                color: PadColor::Yellow,
+            }]),
+        );
 
         for i in 60..TOTAL_PADS {
             assert_eq!(repo.pads[i].off_color, PadColor::Yellow);
@@ -573,7 +602,7 @@ mod tests {
         use crate::manufacturer::akai::mpd226::ColorSequence;
 
         let mut repo = PadRepository::default();
-        let pattern = ColorPattern::Grouped(vec![
+        let pattern = ColorPattern::Repeating(vec![
             ColorSequence {
                 len: 4,
                 color: PadColor::Red,
@@ -608,7 +637,7 @@ mod tests {
         use crate::manufacturer::akai::mpd226::ColorSequence;
 
         let mut repo = PadRepository::default();
-        let pattern = ColorPattern::Grouped(vec![
+        let pattern = ColorPattern::Repeating(vec![
             ColorSequence {
                 len: 2,
                 color: PadColor::Blue,
@@ -640,7 +669,7 @@ mod tests {
         use crate::manufacturer::akai::mpd226::ColorSequence;
 
         let mut repo = PadRepository::default();
-        let pattern = ColorPattern::Grouped(vec![
+        let pattern = ColorPattern::Repeating(vec![
             ColorSequence {
                 len: 3,
                 color: PadColor::Orange,
@@ -667,7 +696,7 @@ mod tests {
         use crate::manufacturer::akai::mpd226::ColorSequence;
 
         let mut repo = PadRepository::default();
-        let pattern = ColorPattern::Grouped(vec![
+        let pattern = ColorPattern::Repeating(vec![
             ColorSequence {
                 len: 3,
                 color: PadColor::Red,
@@ -702,7 +731,7 @@ mod tests {
     #[test]
     fn test_color_groups_empty_sequences() {
         let mut repo = PadRepository::default();
-        let pattern = ColorPattern::Grouped(vec![]);
+        let pattern = ColorPattern::Repeating(vec![]);
 
         repo.set_off_color_pattern(0, 4, pattern);
 
@@ -716,7 +745,7 @@ mod tests {
         use crate::manufacturer::akai::mpd226::ColorSequence;
 
         let mut repo = PadRepository::default();
-        let pattern = ColorPattern::Grouped(vec![ColorSequence {
+        let pattern = ColorPattern::Repeating(vec![ColorSequence {
             len: 4,
             color: PadColor::Aqua,
         }]);


### PR DESCRIPTION
Breaks compatibility with midilab 0.1.5 since we're removing a ColorPattern variant from the public api.

Grouped is renamed to Repeating
Contiguous is deleted because it's combinatorial possibilities are easily represented by Repeating with only slightly more complex ui.