### PR TITLE
Correct misinterpretation of preset 'settings' as 'global'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Software for programming midi controllers via Sysex messages
 #### Completed features:
     - Sysex deserialization into domain types
     - Pad Mapping
-    - Global Mapping
     - Dial mapping
     - Preset dump
     - Preset send

--- a/gui/src/akai_mpd226_editor.rs
+++ b/gui/src/akai_mpd226_editor.rs
@@ -214,18 +214,18 @@ fn render_header(ui: &mut Ui, ui_state: &mut UiState, outbox: &mut Vec<AppMsg>) 
         ui.horizontal(|ui| {
             ui.label("Slot:");
             ComboBox::from_id_salt("header_preset_slot")
-                .selected_text(format!("{:?}", preset.global.preset_slot))
+                .selected_text(format!("{:?}", preset.settings.preset_slot))
                 .show_ui(ui, |ui| {
                     for slot in PresetSlot::iter() {
                         if ui
                             .selectable_value(
-                                &mut preset.global.preset_slot,
+                                &mut preset.settings.preset_slot,
                                 slot,
                                 format!("{:?}", slot),
                             )
                             .clicked()
                         {
-                            preset.global.preset_slot = slot;
+                            preset.settings.preset_slot = slot;
                         }
                     }
                 });
@@ -235,7 +235,7 @@ fn render_header(ui: &mut Ui, ui_state: &mut UiState, outbox: &mut Vec<AppMsg>) 
             ui.label("Name:");
 
             let mut text = preset
-                .global
+                .settings
                 .preset_name
                 .0
                 .iter()
@@ -254,35 +254,35 @@ fn render_header(ui: &mut Ui, ui_state: &mut UiState, outbox: &mut Vec<AppMsg>) 
             for (i, b) in text.bytes().filter(|b| b.is_ascii()).take(8).enumerate() {
                 buf[i] = b;
             }
-            preset.global.preset_name = PresetName(buf);
+            preset.settings.preset_name = PresetName(buf);
 
             ui.separator();
 
             ui.label("Tempo:");
-            let mut tempo_val = preset.global.tempo.0 as u32;
+            let mut tempo_val = preset.settings.tempo.0 as u32;
             if ui
                 .add(DragValue::new(&mut tempo_val).range(30..=300))
                 .changed()
             {
-                preset.global.tempo = Tempo(tempo_val as u16);
+                preset.settings.tempo = Tempo(tempo_val as u16);
             }
 
             ui.separator();
 
             ui.label("Division:");
             ComboBox::from_id_salt("header_time_division")
-                .selected_text(format!("{}", preset.global.time_division))
+                .selected_text(format!("{}", preset.settings.time_division))
                 .show_ui(ui, |ui| {
                     for variant in TimeDivision::iter() {
                         if ui
                             .selectable_value(
-                                &mut preset.global.time_division,
+                                &mut preset.settings.time_division,
                                 variant,
                                 format!("{}", variant),
                             )
                             .clicked()
                         {
-                            preset.global.time_division = variant;
+                            preset.settings.time_division = variant;
                         }
                     }
                 });
@@ -293,18 +293,18 @@ fn render_header(ui: &mut Ui, ui_state: &mut UiState, outbox: &mut Vec<AppMsg>) 
         ui.horizontal(|ui| {
             ui.label("Div Switch:");
             ComboBox::from_id_salt("header_time_division_switch")
-                .selected_text(format!("{}", preset.global.time_division_switch))
+                .selected_text(format!("{}", preset.settings.time_division_switch))
                 .show_ui(ui, |ui| {
                     for variant in TriggerKind::iter() {
                         if ui
                             .selectable_value(
-                                &mut preset.global.time_division_switch,
+                                &mut preset.settings.time_division_switch,
                                 variant,
                                 format!("{}", variant),
                             )
                             .clicked()
                         {
-                            preset.global.time_division_switch = variant;
+                            preset.settings.time_division_switch = variant;
                         }
                     }
                 });
@@ -313,18 +313,18 @@ fn render_header(ui: &mut Ui, ui_state: &mut UiState, outbox: &mut Vec<AppMsg>) 
 
             ui.label("Repeat:");
             ComboBox::from_id_salt("header_note_repeat_switch")
-                .selected_text(format!("{}", preset.global.note_repeat_switch))
+                .selected_text(format!("{}", preset.settings.note_repeat_switch))
                 .show_ui(ui, |ui| {
                     for variant in TriggerKind::iter() {
                         if ui
                             .selectable_value(
-                                &mut preset.global.note_repeat_switch,
+                                &mut preset.settings.note_repeat_switch,
                                 variant,
                                 format!("{}", variant),
                             )
                             .clicked()
                         {
-                            preset.global.note_repeat_switch = variant;
+                            preset.settings.note_repeat_switch = variant;
                         }
                     }
                 });
@@ -332,31 +332,31 @@ fn render_header(ui: &mut Ui, ui_state: &mut UiState, outbox: &mut Vec<AppMsg>) 
             ui.separator();
 
             ui.label("Gate:");
-            let mut gate_val = preset.global.gate as u8;
+            let mut gate_val = preset.settings.gate as u8;
             if ui
                 .add(DragValue::new(&mut gate_val).range(0..=100))
                 .changed()
                 && let Ok(g) = GateValue::try_from(gate_val)
             {
-                preset.global.gate = g;
+                preset.settings.gate = g;
             }
 
             ui.separator();
 
             ui.label("Swing:");
             ComboBox::from_id_salt("header_swing")
-                .selected_text(format!("{}", preset.global.swing))
+                .selected_text(format!("{}", preset.settings.swing))
                 .show_ui(ui, |ui| {
                     for variant in SwingKind::iter() {
                         if ui
                             .selectable_value(
-                                &mut preset.global.swing,
+                                &mut preset.settings.swing,
                                 variant,
                                 format!("{}", variant),
                             )
                             .clicked()
                         {
-                            preset.global.swing = variant;
+                            preset.settings.swing = variant;
                         }
                     }
                 });
@@ -365,18 +365,18 @@ fn render_header(ui: &mut Ui, ui_state: &mut UiState, outbox: &mut Vec<AppMsg>) 
 
             ui.label("Transport:");
             ComboBox::from_id_salt("header_transport")
-                .selected_text(format!("{}", preset.global.transport))
+                .selected_text(format!("{}", preset.settings.transport))
                 .show_ui(ui, |ui| {
                     for variant in TransportKind::iter() {
                         if ui
                             .selectable_value(
-                                &mut preset.global.transport,
+                                &mut preset.settings.transport,
                                 variant,
                                 format!("{}", variant),
                             )
                             .clicked()
                         {
-                            preset.global.transport = variant;
+                            preset.settings.transport = variant;
                         }
                     }
                 });
@@ -393,7 +393,7 @@ fn render_header(ui: &mut Ui, ui_state: &mut UiState, outbox: &mut Vec<AppMsg>) 
         {
             ui_state.user_error = None;
             outbox.push(AppMsg::Ui(UiEffect::RequestPresetFromDevice(
-                preset.global.preset_slot,
+                preset.settings.preset_slot,
             )));
         }
 

--- a/midilab/src/manufacturer/akai/mpd226.rs
+++ b/midilab/src/manufacturer/akai/mpd226.rs
@@ -3,7 +3,7 @@ use num_enum::TryFromPrimitive;
 
 use crate::error::DeviceStatusDeserializationError;
 use crate::manufacturer::akai::SYSEX_MANUFACTURER_ID;
-use crate::manufacturer::akai::mpd226::control::Global;
+use crate::manufacturer::akai::mpd226::control::PresetSettings;
 use crate::manufacturer::akai::mpd226::control::value_kind::GateValue;
 use crate::manufacturer::akai::mpd226::control::value_kind::PadColor;
 use crate::manufacturer::akai::mpd226::control::value_kind::PresetName;
@@ -15,10 +15,10 @@ use crate::manufacturer::akai::mpd226::control::value_kind::TransportKind;
 use crate::manufacturer::akai::mpd226::control::value_kind::TriggerKind;
 use crate::manufacturer::akai::mpd226::raw::RawDials;
 use crate::manufacturer::akai::mpd226::raw::RawFaders;
-use crate::manufacturer::akai::mpd226::raw::RawGlobal;
 use crate::manufacturer::akai::mpd226::raw::RawHeader;
 use crate::manufacturer::akai::mpd226::raw::RawPads;
 use crate::manufacturer::akai::mpd226::raw::RawPreset;
+use crate::manufacturer::akai::mpd226::raw::RawPresetSettings;
 use crate::manufacturer::akai::mpd226::raw::RawSwitches;
 use crate::manufacturer::akai::mpd226::repository::DialRepository;
 use crate::manufacturer::akai::mpd226::repository::FaderRepository;
@@ -152,7 +152,7 @@ impl TryFrom<Sysex> for DeviceStatus {
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct Preset {
-    pub global: Global,
+    pub settings: PresetSettings,
     pub pads: PadRepository,
     pub dials: DialRepository,
     pub faders: FaderRepository,
@@ -164,7 +164,7 @@ impl Default for Preset {
         const GENERIC_DIAL_CC: [u8; 12] = [3, 9, 14, 15, 52, 53, 54, 55, 83, 85, 86, 87];
         const GENERIC_FADER_CC: [u8; 12] = [20, 21, 22, 23, 61, 62, 63, 70, 92, 93, 94, 95];
         const GENERIC_SWITCH_CC: [u8; 12] = [28, 29, 30, 31, 75, 76, 77, 78, 106, 107, 108, 109];
-        let global = Global::default();
+        let settings = PresetSettings::default();
 
         let mut pads = PadRepository::default(); // todo: this should get some dressing
         let dials = DialRepository::with_cc_values(GENERIC_DIAL_CC);
@@ -314,7 +314,7 @@ impl Default for Preset {
         );
 
         Preset {
-            global,
+            settings,
             pads,
             dials,
             faders,
@@ -327,14 +327,14 @@ impl TryFrom<RawPreset> for Preset {
     type Error = error::PresetDeserializationError;
 
     fn try_from(raw: RawPreset) -> Result<Self, Self::Error> {
-        let global = Global::try_from(raw.global)?;
+        let settings = PresetSettings::try_from(raw.settings)?;
         let pads = PadRepository::try_from(RawPads(raw.pads))?;
         let dials = DialRepository::try_from(RawDials(raw.dials))?;
         let faders = FaderRepository::try_from(RawFaders(raw.faders))?;
         let switches = SwitchRepository::try_from(RawSwitches(raw.switches))?;
 
         Ok(Preset {
-            global,
+            settings,
             pads,
             dials,
             faders,
@@ -345,7 +345,7 @@ impl TryFrom<RawPreset> for Preset {
 
 impl From<&Preset> for RawPreset {
     fn from(preset: &Preset) -> Self {
-        let global = RawGlobal::from(&preset.global);
+        let settings = RawPresetSettings::from(&preset.settings);
 
         let mut pads = [[0u8; 11]; TOTAL_PADS];
         for (i, pad) in preset.pads.pads.iter().enumerate() {
@@ -372,7 +372,7 @@ impl From<&Preset> for RawPreset {
         }
 
         RawPreset {
-            global,
+            settings,
             pads: bytemuck::cast(pads),
             dials: bytemuck::cast(dials),
             faders: bytemuck::cast(faders),
@@ -382,48 +382,50 @@ impl From<&Preset> for RawPreset {
     }
 }
 
-impl TryFrom<RawGlobal> for Global {
-    type Error = error::GlobalDeserializationError;
+impl TryFrom<RawPresetSettings> for PresetSettings {
+    type Error = error::PresetSettingsDeserializationError;
 
-    fn try_from(raw: RawGlobal) -> Result<Self, Self::Error> {
-        use error::GlobalDeserializationError;
-        Ok(Global {
+    fn try_from(raw: RawPresetSettings) -> Result<Self, Self::Error> {
+        use error::PresetSettingsDeserializationError;
+        Ok(PresetSettings {
             preset_slot: PresetSlot::try_from(raw.preset)
-                .map_err(GlobalDeserializationError::PresetSlot)?,
+                .map_err(PresetSettingsDeserializationError::PresetSlot)?,
             preset_name: PresetName(raw.name),
             tempo: Tempo::from_packed_bytes(raw.tempo),
             time_division_switch: TriggerKind::try_from(raw.time_division_switch)
-                .map_err(GlobalDeserializationError::TimeDivisionSwitch)?,
+                .map_err(PresetSettingsDeserializationError::TimeDivisionSwitch)?,
             time_division: TimeDivision::try_from(raw.division)
-                .map_err(GlobalDeserializationError::TimeDivision)?,
+                .map_err(PresetSettingsDeserializationError::TimeDivision)?,
             note_repeat_switch: TriggerKind::try_from(raw.note_repeat_switch)
-                .map_err(GlobalDeserializationError::NoteRepeatSwitch)?,
-            gate: GateValue::try_from(raw.gate).map_err(GlobalDeserializationError::Gate)?,
-            swing: SwingKind::try_from(raw.swing).map_err(GlobalDeserializationError::Swing)?,
+                .map_err(PresetSettingsDeserializationError::NoteRepeatSwitch)?,
+            gate: GateValue::try_from(raw.gate)
+                .map_err(PresetSettingsDeserializationError::Gate)?,
+            swing: SwingKind::try_from(raw.swing)
+                .map_err(PresetSettingsDeserializationError::Swing)?,
             transport: TransportKind::try_from(raw.transport)
-                .map_err(GlobalDeserializationError::Transport)?,
+                .map_err(PresetSettingsDeserializationError::Transport)?,
         })
     }
 }
 
-impl From<&Global> for RawGlobal {
-    fn from(global: &Global) -> Self {
-        RawGlobal {
-            preset: global.preset_slot as u8,
-            name: global.preset_name.0,
+impl From<&PresetSettings> for RawPresetSettings {
+    fn from(settings: &PresetSettings) -> Self {
+        RawPresetSettings {
+            preset: settings.preset_slot as u8,
+            name: settings.preset_name.0,
             un1: 0,
-            tempo: global.tempo.to_packed_bytes(),
-            time_division_switch: global.time_division_switch as u8,
-            division: global.time_division as u8,
-            note_repeat_switch: global.note_repeat_switch as u8,
-            gate: global.gate as u8,
-            swing: global.swing as u8,
+            tempo: settings.tempo.to_packed_bytes(),
+            time_division_switch: settings.time_division_switch as u8,
+            division: settings.time_division as u8,
+            note_repeat_switch: settings.note_repeat_switch as u8,
+            gate: settings.gate as u8,
+            swing: settings.swing as u8,
             un5: 0,
             un6: 0,
             un7: 0,
             un8: 0,
             un9: 0,
-            transport: global.transport as u8,
+            transport: settings.transport as u8,
         }
     }
 }

--- a/midilab/src/manufacturer/akai/mpd226/control.rs
+++ b/midilab/src/manufacturer/akai/mpd226/control.rs
@@ -306,7 +306,7 @@ impl TryFrom<RawSwitch> for Switch {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Global {
+pub struct PresetSettings {
     pub preset_slot: PresetSlot,
     pub preset_name: PresetName,
     pub tempo: Tempo,
@@ -318,7 +318,7 @@ pub struct Global {
     pub transport: TransportKind,
 }
 
-impl Default for Global {
+impl Default for PresetSettings {
     fn default() -> Self {
         Self {
             preset_slot: PresetSlot::default(),
@@ -647,25 +647,25 @@ mod tests {
         }
     }
 
-    mod global {
+    mod preset_settings {
         use super::*;
 
         #[test]
-        fn test_global_default() {
-            let global = Global::default();
-            assert_eq!(global.preset_slot, PresetSlot::RAM);
-            assert_eq!(global.tempo, Tempo(120));
-            assert_eq!(global.time_division, TimeDivision::Div1_16);
-            assert_eq!(global.gate, GateValue::try_from(50).unwrap());
+        fn test_preset_settings_default() {
+            let preset_settings = PresetSettings::default();
+            assert_eq!(preset_settings.preset_slot, PresetSlot::RAM);
+            assert_eq!(preset_settings.tempo, Tempo(120));
+            assert_eq!(preset_settings.time_division, TimeDivision::Div1_16);
+            assert_eq!(preset_settings.gate, GateValue::try_from(50).unwrap());
         }
 
         #[test]
-        fn test_global_direct_mutation() {
-            let mut global = Global::default();
-            assert_eq!(global.tempo, Tempo(120));
+        fn test_preset_settings_direct_mutation() {
+            let mut preset_settings = PresetSettings::default();
+            assert_eq!(preset_settings.tempo, Tempo(120));
 
-            global.tempo = Tempo(140);
-            assert_eq!(global.tempo, Tempo(140));
+            preset_settings.tempo = Tempo(140);
+            assert_eq!(preset_settings.tempo, Tempo(140));
         }
     }
 }

--- a/midilab/src/manufacturer/akai/mpd226/error.rs
+++ b/midilab/src/manufacturer/akai/mpd226/error.rs
@@ -19,8 +19,8 @@ use crate::midi::Note;
 
 #[derive(Debug, thiserror::Error)]
 pub enum PresetDeserializationError {
-    #[error("global: {0}")]
-    Global(#[from] GlobalDeserializationError),
+    #[error("preset settings: {0}")]
+    PresetSettings(#[from] PresetSettingsDeserializationError),
     #[error("pad {index}: {source}")]
     Pad {
         index: usize,
@@ -44,7 +44,7 @@ pub enum PresetDeserializationError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum GlobalDeserializationError {
+pub enum PresetSettingsDeserializationError {
     #[error("invalid preset_slot: {0}")]
     PresetSlot(TryFromPrimitiveError<PresetSlot>),
     #[error("invalid time_division_switch: {0}")]

--- a/midilab/src/manufacturer/akai/mpd226/raw.rs
+++ b/midilab/src/manufacturer/akai/mpd226/raw.rs
@@ -8,7 +8,7 @@ use crate::sysex::Sysex;
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct RawPreset {
-    pub global: RawGlobal,
+    pub settings: RawPresetSettings,
     pub pads: [RawPad; TOTAL_PADS],
     pub dials: [RawDial; 12],
     pub faders: [RawFader; 12],
@@ -41,7 +41,7 @@ pub struct RawHeader {
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
-pub struct RawGlobal {
+pub struct RawPresetSettings {
     pub preset: u8,
     pub name: [u8; 8],
     pub un1: u8,
@@ -146,8 +146,8 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_global_data_size() {
-        assert_eq!(std::mem::size_of::<RawGlobal>(), 23);
+    fn test_raw_preset_settings_data_size() {
+        assert_eq!(std::mem::size_of::<RawPresetSettings>(), 23);
     }
 
     #[test]
@@ -212,8 +212,8 @@ mod tests {
     }
 
     #[test]
-    fn test_raw_global_data_fields() {
-        let global = RawGlobal {
+    fn test_raw_preset_settings_data_fields() {
+        let preset_settings = RawPresetSettings {
             preset: 5,
             name: *b"MyPreset",
             un1: 0,
@@ -231,10 +231,10 @@ mod tests {
             transport: 2,
         };
 
-        assert_eq!(global.preset, 5);
-        assert_eq!(&global.name, b"MyPreset");
-        assert_eq!(global.gate, 75);
-        assert_eq!(global.swing, 56);
+        assert_eq!(preset_settings.preset, 5);
+        assert_eq!(&preset_settings.name, b"MyPreset");
+        assert_eq!(preset_settings.gate, 75);
+        assert_eq!(preset_settings.swing, 56);
     }
 
     #[test]

--- a/midilab/src/message.rs
+++ b/midilab/src/message.rs
@@ -76,7 +76,7 @@ impl AppState {
             }
             AppMsg::Device(msg) => match msg {
                 DeviceStatus::PresetData(preset) => {
-                    let slot = preset.global.preset_slot;
+                    let slot = preset.settings.preset_slot;
                     self.preset = *preset.clone();
                     vec![
                         AppEffect::Ui(UiMsg::UpdatePreset(preset)),
@@ -119,11 +119,11 @@ mod tests {
     use super::*;
     use crate::error::DeviceStatusDeserializationError;
     use crate::error::SysexDeserializationError;
-    use crate::manufacturer::akai::mpd226::control::Global;
+    use crate::manufacturer::akai::mpd226::control::PresetSettings;
 
     fn preset_with_slot(slot: PresetSlot) -> Preset {
         Preset {
-            global: Global {
+            settings: PresetSettings {
                 preset_slot: slot,
                 ..Default::default()
             },
@@ -138,24 +138,24 @@ mod tests {
 
         let effects = app.update(AppMsg::Ui(UiEffect::SendPresetToDevice(Box::new(preset))));
 
-        assert_eq!(app.preset.global.preset_slot, PresetSlot::Slot3);
+        assert_eq!(app.preset.settings.preset_slot, PresetSlot::Slot3);
         let effect = effects.into_iter().next().unwrap();
         assert!(matches!(
             effect,
-            AppEffect::Device(DeviceMsg::SendPreset(p)) if p.global.preset_slot == PresetSlot::Slot3
+            AppEffect::Device(DeviceMsg::SendPreset(p)) if p.settings.preset_slot == PresetSlot::Slot3
         ));
     }
 
     #[test]
     fn request_preset_from_device() {
         let mut app = AppState::default();
-        let original_slot = app.preset.global.preset_slot;
+        let original_slot = app.preset.settings.preset_slot;
 
         let effects = app.update(AppMsg::Ui(UiEffect::RequestPresetFromDevice(
             PresetSlot::Slot4,
         )));
 
-        assert_eq!(app.preset.global.preset_slot, original_slot);
+        assert_eq!(app.preset.settings.preset_slot, original_slot);
         let effect = effects.into_iter().next().unwrap();
         assert!(matches!(
             effect,
@@ -170,11 +170,11 @@ mod tests {
 
         let effects = app.update(AppMsg::Device(DeviceStatus::PresetData(Box::new(preset))));
 
-        assert_eq!(app.preset.global.preset_slot, PresetSlot::Slot1);
+        assert_eq!(app.preset.settings.preset_slot, PresetSlot::Slot1);
         assert_eq!(effects.len(), 2);
         assert!(matches!(
             &effects[0],
-            AppEffect::Ui(UiMsg::UpdatePreset(p)) if p.global.preset_slot == PresetSlot::Slot1
+            AppEffect::Ui(UiMsg::UpdatePreset(p)) if p.settings.preset_slot == PresetSlot::Slot1
         ));
         assert!(matches!(
             &effects[1],
@@ -188,13 +188,13 @@ mod tests {
     #[test]
     fn device_received_preset_ack() {
         let mut app = AppState::default();
-        let original_slot = app.preset.global.preset_slot;
+        let original_slot = app.preset.settings.preset_slot;
 
         let effects = app.update(AppMsg::Device(DeviceStatus::ReceivedPresetAck(
             PresetSlot::Slot7,
         )));
 
-        assert_eq!(app.preset.global.preset_slot, original_slot);
+        assert_eq!(app.preset.settings.preset_slot, original_slot);
         let effect = effects.into_iter().next().unwrap();
         assert!(matches!(
             effect,
@@ -208,11 +208,11 @@ mod tests {
     #[test]
     fn midi_error() {
         let mut app = AppState::default();
-        let original_slot = app.preset.global.preset_slot;
+        let original_slot = app.preset.settings.preset_slot;
 
         let effects = app.update(AppMsg::MidiError(MidiError::ResponseTimeout));
 
-        assert_eq!(app.preset.global.preset_slot, original_slot);
+        assert_eq!(app.preset.settings.preset_slot, original_slot);
         let effect = effects.into_iter().next().unwrap();
         assert!(matches!(
             effect,
@@ -226,13 +226,13 @@ mod tests {
     #[test]
     fn sysex_parse_error() {
         let mut app = AppState::default();
-        let original_slot = app.preset.global.preset_slot;
+        let original_slot = app.preset.settings.preset_slot;
 
         let effects = app.update(AppMsg::SysexParseError(
             SysexDeserializationError::InvalidStart(0x00),
         ));
 
-        assert_eq!(app.preset.global.preset_slot, original_slot);
+        assert_eq!(app.preset.settings.preset_slot, original_slot);
         let effect = effects.into_iter().next().unwrap();
         assert!(matches!(
             effect,
@@ -246,13 +246,13 @@ mod tests {
     #[test]
     fn device_status_parse_error() {
         let mut app = AppState::default();
-        let original_slot = app.preset.global.preset_slot;
+        let original_slot = app.preset.settings.preset_slot;
 
         let effects = app.update(AppMsg::DeviceStatusParseError(
             DeviceStatusDeserializationError::InvalidCommand(0xFF),
         ));
 
-        assert_eq!(app.preset.global.preset_slot, original_slot);
+        assert_eq!(app.preset.settings.preset_slot, original_slot);
         let effect = effects.into_iter().next().unwrap();
         assert!(matches!(
             effect,

--- a/midilab/tests/hil_tests.rs
+++ b/midilab/tests/hil_tests.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use midilab::manufacturer::akai::mpd226::Preset;
-use midilab::manufacturer::akai::mpd226::control::Global;
+use midilab::manufacturer::akai::mpd226::control::PresetSettings;
 use midilab::manufacturer::akai::mpd226::control::value_kind::PresetName;
 use midilab::manufacturer::akai::mpd226::preset_dump_request;
 use midilab::manufacturer::akai::mpd226::preset_send_message;
@@ -117,7 +117,7 @@ fn test_construction_and_transmission_to_device() {
     send_and_verify(&mut conn, &rx, &default, "default");
 
     let hello = Preset {
-        global: Global {
+        settings: PresetSettings {
             preset_name: PresetName(*b"hello   "),
             ..Default::default()
         },
@@ -126,7 +126,7 @@ fn test_construction_and_transmission_to_device() {
     send_and_verify(&mut conn, &rx, &hello, "hello");
 
     let world = Preset {
-        global: Global {
+        settings: PresetSettings {
             preset_name: PresetName(*b"world   "),
             ..Default::default()
         },

--- a/sim/src/manufacturer/akai/akai_mpd226.rs
+++ b/sim/src/manufacturer/akai/akai_mpd226.rs
@@ -78,7 +78,7 @@ impl Mpd226Sim {
                                 return SimEffect::Noop;
                             }
                         };
-                        let slot = preset.global.preset_slot;
+                        let slot = preset.settings.preset_slot;
                         self.presets[slot as usize] = preset;
                         SimEffect::SendSysex(preset_ack_message(slot))
                     }


### PR DESCRIPTION
This is a breaking change; the Global struct ceases to exist and is replaced by PresetSettings