### PR TITLE
Thread midi_io::SysEx end-to-end, drop the Sysex wrapper

### DIFF
--- a/akai_mpd226_editor/src/app.rs
+++ b/akai_mpd226_editor/src/app.rs
@@ -256,11 +256,6 @@ impl AppState {
                     received_at: Instant::now(),
                     kind: UserMsgKind::Error,
                 }))],
-                UserError::SysexParse(e) => vec![AppEffect::Ui(UiMsg::UserMsg(UserMsg {
-                    msg: e.to_string(),
-                    received_at: Instant::now(),
-                    kind: UserMsgKind::Error,
-                }))],
                 UserError::DeviceStatusParse(e) => {
                     vec![AppEffect::Ui(UiMsg::UserMsg(UserMsg {
                         msg: e.to_string(),
@@ -277,7 +272,6 @@ impl AppState {
 mod tests {
     use midilab::error::DeviceStatusParseError;
     use midilab::error::MidiError;
-    use midilab::error::SysexParseError;
     use midilab::manufacturer::akai::mpd226::GlobalParamAck;
     use midilab::manufacturer::akai::mpd226::GlobalParamCmdId;
     use midilab::manufacturer::akai::mpd226::PresetAck;
@@ -375,26 +369,6 @@ mod tests {
 
         let effects = app.update(AppMsg::UserError(UserError::Midi(
             MidiError::ResponseTimeout,
-        )));
-
-        assert_eq!(app.preset.settings.slot, original_slot);
-        let effect = effects.into_iter().next().unwrap();
-        assert!(matches!(
-            effect,
-            AppEffect::Ui(UiMsg::UserMsg(UserMsg {
-                kind: UserMsgKind::Error,
-                ..
-            }))
-        ));
-    }
-
-    #[test]
-    fn sysex_parse_error() {
-        let mut app = AppState::new(AppConfig::default());
-        let original_slot = app.preset.settings.slot;
-
-        let effects = app.update(AppMsg::UserError(UserError::SysexParse(
-            SysexParseError::Codec(midi_io::SysExError::MissingStart),
         )));
 
         assert_eq!(app.preset.settings.slot, original_slot);

--- a/akai_mpd226_editor/src/main.rs
+++ b/akai_mpd226_editor/src/main.rs
@@ -33,7 +33,7 @@ use midilab::manufacturer::akai::mpd226::raw::RawPreset;
 use midilab::manufacturer::akai::mpd226::write_preset_to_device;
 use midilab_io::midi::find_input_port;
 use midilab_io::midi::find_output_port;
-use midilab_io::midi::recv_device_bytes;
+use midilab_io::midi::recv_device;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::unbounded_channel;
 
@@ -89,10 +89,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("failed to init MIDI client");
 
         while let Some(msg) = midi_rx.recv().await {
-            let result: Result<Vec<u8>, MidiError> = handle_midi_msg(&client, msg).await;
+            let result: Result<SysEx, MidiError> = handle_midi_msg(&client, msg).await;
 
             let msg = match result {
-                Ok(bytes) => match DeviceStatus::try_from(bytes.as_slice()) {
+                Ok(sysex) => match DeviceStatus::try_from(sysex) {
                     Ok(msg) => AppMsg::Device(msg),
                     Err(e) => AppMsg::UserError(UserError::DeviceStatusParse(e)),
                 },
@@ -165,7 +165,7 @@ async fn connect_midi_output(client: &Client) -> Result<DestinationConnection, S
         .map_err(|e| format!("Failed to connect to MIDI output: {}", e))
 }
 
-async fn connect_midi_input(client: &Client, tx: UnboundedSender<Vec<u8>>) -> Result<(), String> {
+async fn connect_midi_input(client: &Client, tx: UnboundedSender<SysEx>) -> Result<(), String> {
     let port = find_input_port(client, PORT_NAME)
         .await
         .ok_or_else(|| "MPD226 not found - make sure device is connected".to_string())?;
@@ -177,24 +177,23 @@ async fn connect_midi_input(client: &Client, tx: UnboundedSender<Vec<u8>>) -> Re
     tokio::spawn(async move {
         let mut sysex = conn.into_sysex();
         while let Some(timed) = sysex.recv().await {
-            let _ = tx.send(timed.payload.to_wire_bytes());
+            let _ = tx.send(timed.payload);
         }
     });
 
     Ok(())
 }
 
-async fn send_bytes(output: &DestinationConnection, bytes: &[u8]) -> Result<(), ()> {
-    let sysex = SysEx::try_from(bytes).map_err(|_| ())?;
-    output.send_sysex(&sysex).await.map_err(|_| ())
+async fn send(output: &DestinationConnection, sysex: &SysEx) -> Result<(), ()> {
+    output.send_sysex(sysex).await.map_err(|_| ())
 }
 
-async fn handle_midi_msg(client: &Client, msg: DeviceMsg) -> Result<Vec<u8>, MidiError> {
+async fn handle_midi_msg(client: &Client, msg: DeviceMsg) -> Result<SysEx, MidiError> {
     let output = connect_midi_output(client)
         .await
         .map_err(MidiError::OutputConnection)?;
 
-    let (tx, mut rx) = unbounded_channel::<Vec<u8>>();
+    let (tx, mut rx) = unbounded_channel::<SysEx>();
     connect_midi_input(client, tx)
         .await
         .map_err(MidiError::InputConnection)?;
@@ -202,48 +201,46 @@ async fn handle_midi_msg(client: &Client, msg: DeviceMsg) -> Result<Vec<u8>, Mid
     match msg {
         DeviceMsg::DumpPreset(slot) => {
             let request = dump_preset_from_device(slot as u8);
-            send_bytes(&output, &request)
+            send(&output, &request)
                 .await
                 .map_err(|_| MidiError::DumpPreset)?;
 
-            let bytes = recv_device_bytes(&mut rx, Duration::from_secs(2)).await?;
-            Ok(bytes)
+            Ok(recv_device(&mut rx, Duration::from_secs(2)).await?)
         }
         DeviceMsg::WritePreset(preset) => {
             let raw_preset = RawPreset::from(preset.as_ref());
-            let bytes = write_preset_to_device(&raw_preset);
-            send_bytes(&output, &bytes)
+            send(&output, &write_preset_to_device(&raw_preset))
                 .await
                 .map_err(|_| MidiError::WritePreset)?;
 
-            let bytes = recv_device_bytes(&mut rx, Duration::from_secs(2)).await?;
-            Ok(bytes)
+            Ok(recv_device(&mut rx, Duration::from_secs(2)).await?)
         }
         DeviceMsg::DumpGlobal => {
             let request = dump_global_from_device();
-            send_bytes(&output, &request)
+            send(&output, &request)
                 .await
                 .map_err(|_| MidiError::DumpPreset)?;
 
-            let bytes = recv_device_bytes(&mut rx, Duration::from_secs(2)).await?;
-            Ok(bytes)
+            Ok(recv_device(&mut rx, Duration::from_secs(2)).await?)
         }
         DeviceMsg::WriteGlobal(global) => {
             let raw_global = RawGlobal::from(global.as_ref());
             let messages = raw_global.global_send_messages();
 
-            let mut bytes = vec![];
+            let mut ack = None;
 
             for msg in messages {
-                send_bytes(&output, &msg)
+                send(&output, &msg)
                     .await
                     .map_err(|_| MidiError::WritePreset)?;
-                bytes = recv_device_bytes(&mut rx, Duration::from_millis(500))
-                    .await
-                    .unwrap();
+                ack = Some(
+                    recv_device(&mut rx, Duration::from_millis(500))
+                        .await
+                        .unwrap(),
+                );
             }
 
-            Ok(bytes)
+            Ok(ack.expect("global_send_messages is never empty"))
         }
     }
 }

--- a/akai_mpd226_editor/src/message.rs
+++ b/akai_mpd226_editor/src/message.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 
 use midilab::error::DeviceStatusParseError;
 use midilab::error::MidiError;
-use midilab::error::SysexParseError;
 use midilab::manufacturer::akai::mpd226::DeviceStatus;
 use midilab::manufacturer::akai::mpd226::Global;
 use midilab::manufacturer::akai::mpd226::Preset;
@@ -21,7 +20,6 @@ pub enum AppMsg {
 
 pub enum UserError {
     Midi(MidiError),
-    SysexParse(SysexParseError),
     DeviceStatusParse(DeviceStatusParseError),
 }
 

--- a/arturia_minilab_mk2_editor/src/main.rs
+++ b/arturia_minilab_mk2_editor/src/main.rs
@@ -32,7 +32,7 @@ use midilab::manufacturer::arturia::minilab_mk2::set_pad_live_color_message;
 use midilab::manufacturer::arturia::minilab_mk2::store_memory_message;
 use midilab_io::midi::find_input_port;
 use midilab_io::midi::find_output_port;
-use midilab_io::midi::recv_device_bytes;
+use midilab_io::midi::recv_device;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::unbounded_channel;
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await
             .expect("failed to init MIDI client");
 
-        let (dev_tx, mut dev_rx) = unbounded_channel::<Vec<u8>>();
+        let (dev_tx, mut dev_rx) = unbounded_channel::<SysEx>();
         let mut output: Option<DestinationConnection> = connect_output(&client).await.ok();
         let mut input = connect_input(&client, dev_tx.clone()).await.ok();
 
@@ -179,7 +179,7 @@ async fn connect_output(client: &Client) -> Result<DestinationConnection, String
         .map_err(|e| format!("Failed to connect to MIDI output: {}", e))
 }
 
-async fn connect_input(client: &Client, tx: UnboundedSender<Vec<u8>>) -> Result<(), String> {
+async fn connect_input(client: &Client, tx: UnboundedSender<SysEx>) -> Result<(), String> {
     let port = find_input_port(client, PORT_NAME)
         .await
         .ok_or_else(|| format!("MiniLab not found (no '{PORT_NAME}' input) - is it connected?"))?;
@@ -191,29 +191,28 @@ async fn connect_input(client: &Client, tx: UnboundedSender<Vec<u8>>) -> Result<
     tokio::spawn(async move {
         let mut sysex = conn.into_sysex();
         while let Some(timed) = sysex.recv().await {
-            let _ = tx.send(timed.payload.to_wire_bytes());
+            let _ = tx.send(timed.payload);
         }
     });
 
     Ok(())
 }
 
-async fn send_bytes(output: &DestinationConnection, bytes: &[u8]) -> Result<(), MidiError> {
-    let sysex = SysEx::try_from(bytes).map_err(|e| MidiError::OutputConnection(e.to_string()))?;
+async fn send(output: &DestinationConnection, sysex: &SysEx) -> Result<(), MidiError> {
     output
-        .send_sysex(&sysex)
+        .send_sysex(sysex)
         .await
         .map_err(|e| MidiError::OutputConnection(e.to_string()))
 }
 
-fn drain(rx: &mut UnboundedReceiver<Vec<u8>>) {
+fn drain(rx: &mut UnboundedReceiver<SysEx>) {
     while rx.try_recv().is_ok() {}
 }
 
 async fn handle_midi_msg(
     msg: DeviceMsg,
     output: &DestinationConnection,
-    rx: &mut UnboundedReceiver<Vec<u8>>,
+    rx: &mut UnboundedReceiver<SysEx>,
 ) -> Result<DeviceEvent, UserError> {
     match msg {
         DeviceMsg::ReadPreset => {
@@ -231,9 +230,7 @@ async fn handle_midi_msg(
         DeviceMsg::WritePreset(preset) => {
             drain(rx);
             for message in preset.send_messages() {
-                send_bytes(output, &message)
-                    .await
-                    .map_err(UserError::Midi)?;
+                send(output, &message).await.map_err(UserError::Midi)?;
                 tokio::time::sleep(WRITE_PACING).await;
             }
             drain(rx);
@@ -254,16 +251,14 @@ async fn handle_midi_msg(
         DeviceMsg::WriteGlobal(global) => {
             drain(rx);
             for message in global.send_messages() {
-                send_bytes(output, &message)
-                    .await
-                    .map_err(UserError::Midi)?;
+                send(output, &message).await.map_err(UserError::Midi)?;
                 tokio::time::sleep(WRITE_PACING).await;
             }
             drain(rx);
             Ok(DeviceEvent::GlobalWritten)
         }
         DeviceMsg::RecallMemory(slot) => {
-            send_bytes(output, &recall_memory_message(slot))
+            send(output, &recall_memory_message(slot))
                 .await
                 .map_err(UserError::Midi)?;
             tokio::time::sleep(MEMORY_OP_SETTLE).await;
@@ -271,7 +266,7 @@ async fn handle_midi_msg(
             Ok(DeviceEvent::MemoryRecalled(slot))
         }
         DeviceMsg::StoreMemory(slot) => {
-            send_bytes(output, &store_memory_message(slot))
+            send(output, &store_memory_message(slot))
                 .await
                 .map_err(UserError::Midi)?;
             tokio::time::sleep(MEMORY_OP_SETTLE).await;
@@ -279,7 +274,7 @@ async fn handle_midi_msg(
             Ok(DeviceEvent::MemoryStored(slot))
         }
         DeviceMsg::SetLivePadColor { pad, color } => {
-            send_bytes(output, &set_pad_live_color_message(pad, color))
+            send(output, &set_pad_live_color_message(pad, color))
                 .await
                 .map_err(UserError::Midi)?;
             Ok(DeviceEvent::LiveColorSent)
@@ -289,12 +284,12 @@ async fn handle_midi_msg(
 
 async fn request_status(
     output: &DestinationConnection,
-    rx: &mut UnboundedReceiver<Vec<u8>>,
-    message: &[u8],
+    rx: &mut UnboundedReceiver<SysEx>,
+    message: &SysEx,
 ) -> Result<DeviceStatus, UserError> {
-    send_bytes(output, message).await.map_err(UserError::Midi)?;
-    let bytes = recv_device_bytes(rx, READ_TIMEOUT)
+    send(output, message).await.map_err(UserError::Midi)?;
+    let sysex = recv_device(rx, READ_TIMEOUT)
         .await
         .map_err(UserError::Midi)?;
-    DeviceStatus::try_from(bytes.as_slice()).map_err(|e| UserError::Parse(e.to_string()))
+    DeviceStatus::try_from(sysex).map_err(|e| UserError::Parse(e.to_string()))
 }

--- a/io/src/midi.rs
+++ b/io/src/midi.rs
@@ -25,10 +25,10 @@ pub async fn find_input_port(client: &Client, name: &str) -> Option<Source> {
         .find(|p| p.name() == name)
 }
 
-pub async fn recv_device_bytes(
-    rx: &mut UnboundedReceiver<Vec<u8>>,
+pub async fn recv_device<T>(
+    rx: &mut UnboundedReceiver<T>,
     timeout_duration: Duration,
-) -> Result<Vec<u8>, MidiError> {
+) -> Result<T, MidiError> {
     match timeout(timeout_duration, rx.recv()).await {
         Ok(Some(bytes)) => Ok(bytes),
         Ok(None) => Err(MidiError::ChannelClosed),

--- a/korg_r3_editor/src/app.rs
+++ b/korg_r3_editor/src/app.rs
@@ -465,7 +465,7 @@ mod tests {
             value: 77,
         }
         .to_sysex(0x00);
-        let kmsg = KorgR3Message::try_from(bytes.as_slice()).expect("valid sysex");
+        let kmsg = KorgR3Message::try_from(&bytes).expect("valid sysex");
 
         let effects = app.update(AppMsg::Device(kmsg));
 

--- a/korg_r3_editor/src/main.rs
+++ b/korg_r3_editor/src/main.rs
@@ -39,7 +39,7 @@ use midilab::manufacturer::korg::r3::program_write_request;
 use midilab::manufacturer::korg::r3::raw::RawProgram;
 use midilab_io::midi::find_input_port;
 use midilab_io::midi::find_output_port;
-use midilab_io::midi::recv_device_bytes;
+use midilab_io::midi::recv_device;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::unbounded_channel;
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await
             .expect("failed to init MIDI client");
 
-        let (dev_tx, mut dev_rx) = unbounded_channel::<Vec<u8>>();
+        let (dev_tx, mut dev_rx) = unbounded_channel::<SysEx>();
         let mut output: Option<DestinationConnection> = connect_output(&client).await.ok();
         let mut input = connect_input(&client, dev_tx.clone()).await.ok();
 
@@ -119,8 +119,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         const IDLE_TICK: Duration = Duration::from_millis(50);
 
         loop {
-            while let Ok(bytes) = dev_rx.try_recv() {
-                if let Ok(kmsg) = KorgR3Message::try_from(bytes.as_slice()) {
+            while let Ok(sysex) = dev_rx.try_recv() {
+                if let Ok(kmsg) = KorgR3Message::try_from(&sysex) {
                     let _ = midi_app_tx.send(AppMsg::Device(kmsg));
                 }
             }
@@ -131,7 +131,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             addr: ParamAddr { id, sub },
                             value,
                         };
-                        let _ = send_bytes(out, &lp.to_sysex(0x00)).await;
+                        let _ = send(out, &lp.to_sysex(0x00)).await;
                     }
                 } else {
                     pending.clear();
@@ -173,13 +173,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             let out = output.as_ref().unwrap();
 
-            let result: Result<Vec<u8>, MidiError> = handle_midi_msg(msg, out, &mut dev_rx).await;
+            let result = handle_midi_msg(msg, out, &mut dev_rx).await;
 
             let msg = match result {
-                Ok(bytes) => match KorgR3Message::try_from(bytes.as_slice()) {
+                Ok(Some(sysex)) => match KorgR3Message::try_from(&sysex) {
                     Ok(kmsg) => AppMsg::Device(kmsg),
                     Err(_) => continue,
                 },
+                Ok(None) => continue,
                 Err(e) => AppMsg::UserError(UserError::Midi(e)),
             };
             let _ = midi_app_tx.send(msg);
@@ -239,7 +240,7 @@ async fn connect_output(client: &Client) -> Result<DestinationConnection, String
         .map_err(|e| format!("Failed to connect to MIDI output: {}", e))
 }
 
-async fn connect_input(client: &Client, tx: UnboundedSender<Vec<u8>>) -> Result<(), String> {
+async fn connect_input(client: &Client, tx: UnboundedSender<SysEx>) -> Result<(), String> {
     let port = find_input_port(client, PORT_KBD_KNOB)
         .await
         .ok_or_else(|| format!("R3 not found (no '{PORT_KBD_KNOB}' input) - is it connected?"))?;
@@ -251,124 +252,126 @@ async fn connect_input(client: &Client, tx: UnboundedSender<Vec<u8>>) -> Result<
     tokio::spawn(async move {
         let mut sysex = conn.into_sysex();
         while let Some(timed) = sysex.recv().await {
-            let _ = tx.send(timed.payload.to_wire_bytes());
+            let _ = tx.send(timed.payload);
         }
     });
 
     Ok(())
 }
 
-async fn send_bytes(output: &DestinationConnection, bytes: &[u8]) -> Result<(), ()> {
-    let sysex = SysEx::try_from(bytes).map_err(|_| ())?;
-    output.send_sysex(&sysex).await.map_err(|_| ())
+async fn send(output: &DestinationConnection, sysex: &SysEx) -> Result<(), ()> {
+    output.send_sysex(sysex).await.map_err(|_| ())
 }
 
 async fn handle_midi_msg(
     msg: DeviceMsg,
     output: &DestinationConnection,
-    rx: &mut UnboundedReceiver<Vec<u8>>,
-) -> Result<Vec<u8>, MidiError> {
+    rx: &mut UnboundedReceiver<SysEx>,
+) -> Result<Option<SysEx>, MidiError> {
     match msg {
         DeviceMsg::DumpCurrentProgram => {
             let request = current_program_dump_request(0x00);
-            send_bytes(output, &request)
+            send(output, &request)
                 .await
                 .map_err(|_| MidiError::DumpPreset)?;
 
-            let bytes = recv_device_bytes(rx, Duration::from_secs(3)).await?;
-            Ok(bytes)
+            let sysex = recv_device(rx, Duration::from_secs(3)).await?;
+            Ok(Some(sysex))
         }
         DeviceMsg::DumpProgram(slot) => {
             let request = midilab::manufacturer::korg::r3::program_dump_request(0x00, slot as u16);
-            send_bytes(output, &request)
+            send(output, &request)
                 .await
                 .map_err(|_| MidiError::DumpPreset)?;
 
-            let bytes = recv_device_bytes(rx, Duration::from_secs(3)).await?;
-            Ok(bytes)
+            let sysex = recv_device(rx, Duration::from_secs(3)).await?;
+            Ok(Some(sysex))
         }
         DeviceMsg::DumpSlot(slot) => {
             let request =
                 midilab::manufacturer::korg::r3::program_dump_request(0x00, slot.as_u16());
-            send_bytes(output, &request)
+            send(output, &request)
                 .await
                 .map_err(|_| MidiError::DumpPreset)?;
 
-            let bytes = recv_device_bytes(rx, Duration::from_secs(3)).await?;
-            Ok(bytes)
+            let sysex = recv_device(rx, Duration::from_secs(3)).await?;
+            Ok(Some(sysex))
         }
         DeviceMsg::DumpGlobal => {
             let request = global_dump_request(0x00);
-            send_bytes(output, &request)
+            send(output, &request)
                 .await
                 .map_err(|_| MidiError::DumpPreset)?;
 
-            let bytes = recv_device_bytes(rx, Duration::from_secs(3)).await?;
-            Ok(bytes)
+            let sysex = recv_device(rx, Duration::from_secs(3)).await?;
+            Ok(Some(sysex))
         }
         DeviceMsg::DumpCurrentFormantMotion => {
             let request = current_formant_motion_dump_request(0x00);
-            send_bytes(output, &request)
+            send(output, &request)
                 .await
                 .map_err(|_| MidiError::DumpPreset)?;
 
-            let bytes = recv_device_bytes(rx, Duration::from_secs(3)).await?;
-            Ok(bytes)
+            let sysex = recv_device(rx, Duration::from_secs(3)).await?;
+            Ok(Some(sysex))
         }
         DeviceMsg::DumpFormantMotion(motion_no) => {
             let request = formant_motion_dump_request(0x00, motion_no);
-            send_bytes(output, &request)
+            send(output, &request)
                 .await
                 .map_err(|_| MidiError::DumpPreset)?;
 
-            let bytes = recv_device_bytes(rx, Duration::from_secs(3)).await?;
-            Ok(bytes)
+            let sysex = recv_device(rx, Duration::from_secs(3)).await?;
+            Ok(Some(sysex))
         }
         DeviceMsg::WriteProgram { program, slot } => {
             let raw: RawProgram = (&*program).into();
-            do_write_program(output, rx, &raw, slot as u16).await
+            do_write_program(output, rx, &raw, slot as u16).await?;
+            Ok(None)
         }
         DeviceMsg::WriteSelectedProgram { program, slot } => {
             let raw: RawProgram = (&*program).into();
-            do_write_program(output, rx, &raw, slot.as_u16()).await
+            do_write_program(output, rx, &raw, slot.as_u16()).await?;
+            Ok(None)
         }
         DeviceMsg::WriteFormantMotion { motion, motion_no } => {
-            do_write_formant_motion(output, rx, &motion, motion_no).await
+            do_write_formant_motion(output, rx, &motion, motion_no).await?;
+            Ok(None)
         }
-        DeviceMsg::LiveParams(_) => Ok(vec![]),
+        DeviceMsg::LiveParams(_) => Ok(None),
     }
 }
 
 async fn do_write_program(
     output: &DestinationConnection,
-    rx: &mut UnboundedReceiver<Vec<u8>>,
+    rx: &mut UnboundedReceiver<SysEx>,
     program: &RawProgram,
     slot: u16,
-) -> Result<Vec<u8>, MidiError> {
+) -> Result<(), MidiError> {
     while let Ok(_v) = rx.try_recv() {}
 
-    send_bytes(output, &current_program_dump_message(0x00, program))
+    send(output, &current_program_dump_message(0x00, program))
         .await
         .map_err(|_| MidiError::WritePreset)?;
     wait_for_ack(rx).await?;
 
-    send_bytes(output, &program_write_request(0x00, slot))
+    send(output, &program_write_request(0x00, slot))
         .await
         .map_err(|_| MidiError::WritePreset)?;
     wait_for_ack(rx).await?;
 
-    Ok(vec![])
+    Ok(())
 }
 
 async fn do_write_formant_motion(
     output: &DestinationConnection,
-    rx: &mut UnboundedReceiver<Vec<u8>>,
+    rx: &mut UnboundedReceiver<SysEx>,
     motion: &midilab::manufacturer::korg::r3::wrappers::FormantMotion,
     motion_no: u8,
-) -> Result<Vec<u8>, MidiError> {
+) -> Result<(), MidiError> {
     while let Ok(_v) = rx.try_recv() {}
 
-    send_bytes(
+    send(
         output,
         &current_formant_motion_dump_message(0x00, &motion.to_raw()),
     )
@@ -376,19 +379,19 @@ async fn do_write_formant_motion(
     .map_err(|_| MidiError::WritePreset)?;
     wait_for_ack(rx).await?;
 
-    send_bytes(output, &formant_motion_write_request(0x00, motion_no))
+    send(output, &formant_motion_write_request(0x00, motion_no))
         .await
         .map_err(|_| MidiError::WritePreset)?;
     wait_for_ack(rx).await?;
 
-    Ok(vec![])
+    Ok(())
 }
 
 async fn wait_for_ack(
-    rx: &mut tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<SysEx>,
 ) -> Result<(), MidiError> {
-    match recv_device_bytes(rx, Duration::from_secs(10)).await {
-        Ok(bytes) => match KorgR3Message::try_from(bytes.as_slice()) {
+    match recv_device(rx, Duration::from_secs(10)).await {
+        Ok(sysex) => match KorgR3Message::try_from(&sysex) {
             Ok(KorgR3Message::DataLoadCompleted) | Ok(KorgR3Message::WriteCompleted) => Ok(()),
             _ => Ok(()),
         },

--- a/midilab/README.md
+++ b/midilab/README.md
@@ -12,24 +12,24 @@ cargo add midilab
 
 ### Examples
 
-Parse raw bytes into a Sysex message:
+Parse raw bytes into a SysEx message:
 ```rust
-use midilab::sysex::Sysex;
+use midilab::sysex::SysEx;
 
 let bytes: &[u8] = &[0xf0, 0x47, 0x00, 0x35, 0xf7];
-let sysex = Sysex::try_from(bytes).unwrap();
-assert_eq!(sysex.payload(), &[0x47, 0x00, 0x35]);
+let sysex = SysEx::try_from(bytes).unwrap();
+assert_eq!(sysex.bytes(), &[0x47, 0x00, 0x35]);
 ```
 
 Deserialize an Akai MPD226 preset acknowledgment:
 ```rust
-use midilab::sysex::Sysex;
+use midilab::sysex::SysEx;
 use midilab::manufacturer::akai::mpd226::DeviceStatus;
 
-// Deserialize an Akai Mpd226's raw PresetAck bytes into Sysex
+// Deserialize an Akai Mpd226's raw PresetAck bytes into SysEx
 let bytes: &[u8] = &[0xf0, 0x47, 0x00, 0x35, 0x11, 0x00, 0x01, 0x00, 0x00, 0xf7];
-let sysex = Sysex::try_from(bytes).unwrap();
-// Deserialize the Sysex into a DeviceStatus variant
+let sysex = SysEx::try_from(bytes).unwrap();
+// Deserialize the SysEx into a DeviceStatus variant
 let status = DeviceStatus::try_from(sysex).unwrap();
 ```
 

--- a/midilab/src/error.rs
+++ b/midilab/src/error.rs
@@ -20,18 +20,11 @@ pub enum MidiError {
     ChannelClosed,
 }
 
-/// Enumerates error states of Sysex deserialization
-#[derive(thiserror::Error, Debug)]
-pub enum SysexParseError {
-    #[error("invalid sysex: {0}")]
-    Codec(#[from] midi_io::SysExError),
-}
-
 /// Enumerates error states of DeviceStatus deserialization
 #[derive(Debug, thiserror::Error)]
 pub enum DeviceStatusParseError {
     #[error("invalid sysex: {0}")]
-    InvalidSysex(#[from] SysexParseError),
+    InvalidSysex(#[from] midi_io::SysExError),
     #[error("invalid msg")]
     InvalidMsg,
     #[error("invalid header")]

--- a/midilab/src/lib.rs
+++ b/midilab/src/lib.rs
@@ -8,7 +8,7 @@ pub mod manufacturer;
 pub mod midi;
 /// Music theory
 pub mod music;
-///  Sysex deserialization
+/// Sysex framing and 7-bit packing utilities
 pub mod sysex;
 
 /// Convienence re-export so consuming crates of our library one can use derived EnumIter features for our types

--- a/midilab/src/manufacturer/akai/mpd226.rs
+++ b/midilab/src/manufacturer/akai/mpd226.rs
@@ -42,7 +42,8 @@ use crate::manufacturer::akai::mpd226::repository::PadRepository;
 use crate::manufacturer::akai::mpd226::repository::SwitchRepository;
 use crate::music::generation::PitchPattern;
 use crate::music::theory::PitchClass;
-use crate::sysex::Sysex;
+use crate::sysex::SysEx;
+use crate::sysex::from_header_and_body;
 use crate::sysex::unpack_u14;
 
 pub mod control;
@@ -97,17 +98,17 @@ pub enum DeviceCommandId {
     WriteGlobal = 0x34,
 }
 
-pub fn dump_preset_from_device(slot: u8) -> Vec<u8> {
+pub fn dump_preset_from_device(slot: u8) -> SysEx {
     let header = RawHeader::dump_preset();
-    Sysex::from_header_and_body_as_bytes(&header, [slot])
+    from_header_and_body(&header, [slot])
 }
 
-pub fn write_preset_to_device(preset: &RawPreset) -> Vec<u8> {
+pub fn write_preset_to_device(preset: &RawPreset) -> SysEx {
     let header = RawHeader::write_preset();
-    Sysex::from_header_and_body_as_bytes(&header, bytemuck::bytes_of(preset))
+    from_header_and_body(&header, bytemuck::bytes_of(preset))
 }
 
-pub fn dump_global_from_device() -> Vec<u8> {
+pub fn dump_global_from_device() -> SysEx {
     let length = u16::from_le_bytes([0x00, 0x03]).to_le_bytes();
     let header = RawHeader {
         mfg_id: SYSEX_MANUFACTURER_ID,
@@ -116,10 +117,10 @@ pub fn dump_global_from_device() -> Vec<u8> {
         cmd: DeviceCommandId::DumpGlobal.into(),
         length,
     };
-    Sysex::from_header_and_body_as_bytes(&header, SEND_GLOBAL_PADDING_BYTES)
+    from_header_and_body(&header, SEND_GLOBAL_PADDING_BYTES)
 }
 
-pub fn write_global_param_to_device(addr: u8, value: u8) -> Vec<u8> {
+pub fn write_global_param_to_device(addr: u8, value: u8) -> SysEx {
     let length = u16::from_le_bytes([0x00, 0x04]).to_le_bytes();
     let header = RawHeader {
         mfg_id: SYSEX_MANUFACTURER_ID,
@@ -128,7 +129,7 @@ pub fn write_global_param_to_device(addr: u8, value: u8) -> Vec<u8> {
         cmd: DeviceCommandId::WriteGlobal.into(),
         length,
     };
-    Sysex::from_header_and_body_as_bytes(
+    from_header_and_body(
         &header,
         [GLOBAL_VALUE_MAGIC[0], GLOBAL_VALUE_MAGIC[1], addr, value],
     )
@@ -142,7 +143,7 @@ impl<C: TryFrom<u8>> TryFrom<&[u8]> for DeviceMessagePayload<C> {
     type Error = DeviceStatusParseError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let s = Sysex::try_from(value)?;
+        let s = SysEx::try_from(value)?;
         DeviceMessagePayload::try_from(s)
     }
 }
@@ -152,16 +153,16 @@ pub struct DeviceHeader<C> {
     pub cmd: C,
     pub message_length: u16,
 }
-impl<C: TryFrom<u8>> TryFrom<Sysex> for DeviceMessagePayload<C> {
+impl<C: TryFrom<u8>> TryFrom<SysEx> for DeviceMessagePayload<C> {
     type Error = DeviceStatusParseError;
 
-    fn try_from(value: Sysex) -> Result<DeviceMessagePayload<C>, Self::Error> {
+    fn try_from(value: SysEx) -> Result<DeviceMessagePayload<C>, Self::Error> {
         let header_size = std::mem::size_of::<RawHeader>();
-        if value.payload().len() < header_size {
+        if value.bytes().len() < header_size {
             return Err(DeviceStatusParseError::InvalidHeader);
         }
 
-        let (hb, pb) = &value.payload().split_at(header_size);
+        let (hb, pb) = &value.bytes().split_at(header_size);
 
         let raw_header: RawHeader =
             *bytemuck::try_from_bytes(hb).map_err(|_| DeviceStatusParseError::InvalidHeader)?;
@@ -279,13 +280,11 @@ impl TryFrom<DeviceMessagePayload<DeviceStatusId>> for DeviceStatus {
         }
     }
 }
-impl TryFrom<Sysex> for DeviceStatus {
+impl TryFrom<SysEx> for DeviceStatus {
     type Error = DeviceStatusParseError;
 
-    fn try_from(value: Sysex) -> Result<Self, Self::Error> {
-        let payload: DeviceMessagePayload<DeviceStatusId> =
-            DeviceMessagePayload::try_from(value.clone())
-                .map_err(|_e| DeviceStatusParseError::InvalidHeader)?;
+    fn try_from(value: SysEx) -> Result<Self, Self::Error> {
+        let payload: DeviceMessagePayload<DeviceStatusId> = DeviceMessagePayload::try_from(value)?;
 
         DeviceStatus::try_from(payload)
     }
@@ -328,10 +327,10 @@ impl Preset {
         bytemuck::bytes_of(&raw).to_vec()
     }
 
-    pub fn as_sysex_write(&self) -> Sysex {
+    pub fn as_sysex_write(&self) -> SysEx {
         let preset_bytes = self.as_bytes();
         let header = RawHeader::write_preset();
-        Sysex::from_header_and_body(&header, preset_bytes)
+        from_header_and_body(&header, preset_bytes)
     }
 
     pub fn default_filename(&self) -> String {
@@ -808,7 +807,7 @@ mod tests {
     use crate::midi::NoteSequence;
     use crate::music::generation::PitchPattern;
     use crate::music::generation::ScaleSequence;
-    use crate::sysex::Sysex;
+    use crate::sysex::SysEx;
 
     #[test]
     fn test_pad_repository_direct_mutation() {
@@ -876,7 +875,7 @@ mod tests {
 
     #[test]
     fn test_global_dump_request_format() {
-        let request = dump_global_from_device();
+        let request = dump_global_from_device().to_wire_bytes();
 
         assert_eq!(request.len(), 11);
         assert_eq!(request[0], 0xF0);
@@ -894,7 +893,7 @@ mod tests {
 
     #[test]
     fn test_global_write_param_format() {
-        let msg = write_global_param_to_device(0x02, 50);
+        let msg = write_global_param_to_device(0x02, 50).to_wire_bytes();
 
         assert_eq!(msg.len(), 12);
         assert_eq!(msg[0], 0xF0);
@@ -919,7 +918,7 @@ mod tests {
         assert_eq!(messages.len(), 11);
 
         for msg in &messages {
-            assert_eq!(msg.len(), 12);
+            assert_eq!(msg.to_wire_bytes().len(), 12);
         }
     }
 
@@ -969,7 +968,7 @@ mod tests {
         assert_eq!(preset2.faders.0[0].channel, MidiChannel::A1,);
         assert_eq!(preset2.switches.0[0].channel, MidiChannel::A1,);
 
-        let sysex_bytes = write_preset_to_device(&raw);
+        let sysex_bytes = write_preset_to_device(&raw).to_wire_bytes();
 
         let data_start = 1 + 6;
         let data_end = sysex_bytes.len() - 1;
@@ -1030,7 +1029,7 @@ mod tests {
             0xF0, 0x47, 0x00, 0x35, 0x3C, 0x04, 0x00, 0x01, 0x00, 0x02, 0x00, 0xF7,
         ];
 
-        let sysex = Sysex::try_from(bytes.as_slice()).unwrap();
+        let sysex = SysEx::try_from(bytes.as_slice()).unwrap();
         let status = DeviceStatus::try_from(sysex).unwrap();
 
         let ack = match status {

--- a/midilab/src/manufacturer/akai/mpd226/raw.rs
+++ b/midilab/src/manufacturer/akai/mpd226/raw.rs
@@ -7,7 +7,8 @@ use crate::manufacturer::akai::mpd226::DeviceCommandId;
 use crate::manufacturer::akai::mpd226::DeviceHeader;
 use crate::manufacturer::akai::mpd226::GLOBAL_VALUE_MAGIC;
 use crate::manufacturer::akai::mpd226::TOTAL_PADS;
-use crate::sysex::Sysex;
+use crate::sysex::SysEx;
+use crate::sysex::from_header_and_body;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
@@ -213,14 +214,14 @@ impl RawGlobal {
 
     /// Send all global parameters to device (as individual writes)
     /// Returns Vec of sysex messages, one per parameter
-    pub fn global_send_messages(&self) -> Vec<Vec<u8>> {
+    pub fn global_send_messages(&self) -> Vec<SysEx> {
         self.param_pairs()
             .into_iter()
             .map(|(addr, value)| Self::global_write_param(addr, value))
             .collect()
     }
 
-    fn global_write_param(addr: u8, value: u8) -> Vec<u8> {
+    fn global_write_param(addr: u8, value: u8) -> SysEx {
         let length = u16::from_le_bytes([0x00, 0x04]).to_le_bytes();
         let header = RawHeader {
             mfg_id: SYSEX_MANUFACTURER_ID,
@@ -229,7 +230,7 @@ impl RawGlobal {
             cmd: DeviceCommandId::WriteGlobal as u8,
             length,
         };
-        Sysex::from_header_and_body_as_bytes(
+        from_header_and_body(
             &header,
             [GLOBAL_VALUE_MAGIC[0], GLOBAL_VALUE_MAGIC[1], addr, value],
         )
@@ -343,7 +344,7 @@ mod tests {
 
     #[test]
     fn test_preset_dump_request_ram() {
-        let request = dump_preset_from_device(0x00);
+        let request = dump_preset_from_device(0x00).to_wire_bytes();
 
         assert_eq!(request.len(), 9);
         assert_eq!(request[0], 0xF0);
@@ -359,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_preset_dump_request_slot_0() {
-        let request = dump_preset_from_device(0x00);
+        let request = dump_preset_from_device(0x00).to_wire_bytes();
 
         assert_eq!(request.len(), 9);
         assert_eq!(request[7], 0x00);

--- a/midilab/src/manufacturer/arturia/minilab_mk2.rs
+++ b/midilab/src/manufacturer/arturia/minilab_mk2.rs
@@ -29,7 +29,8 @@ use crate::manufacturer::arturia::minilab_mk2::raw::RawPreset;
 use crate::manufacturer::arturia::minilab_mk2::repository::ButtonRepository;
 use crate::manufacturer::arturia::minilab_mk2::repository::KnobRepository;
 use crate::manufacturer::arturia::minilab_mk2::repository::PadRepository;
-use crate::sysex::Sysex;
+use crate::sysex::SysEx;
+use crate::sysex::sysex;
 
 pub mod control;
 pub mod error;
@@ -86,25 +87,25 @@ pub enum GlobalParamId {
     PadOffBacklight = 0x1E,
 }
 
-fn command_message(body: &[u8]) -> Vec<u8> {
+fn command_message(body: &[u8]) -> SysEx {
     let mut payload = SYSEX_COMMAND_HEADER.to_vec();
     payload.extend_from_slice(body);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn read_param_message(param: ParamId, control: ControlId) -> Vec<u8> {
+pub fn read_param_message(param: ParamId, control: ControlId) -> SysEx {
     command_message(&[OpCode::ReadParam.into(), 0x00, param.into(), control.into()])
 }
 
-pub fn write_param_message(param: ParamId, control: ControlId, value: u8) -> Vec<u8> {
+pub fn write_param_message(param: ParamId, control: ControlId, value: u8) -> SysEx {
     write_value_message(param.into(), control.into(), value)
 }
 
-pub fn write_value_message(param: u8, control: u8, value: u8) -> Vec<u8> {
+pub fn write_value_message(param: u8, control: u8, value: u8) -> SysEx {
     command_message(&[OpCode::WriteParam.into(), 0x00, param, control, value])
 }
 
-pub fn read_global_message(param: GlobalParamId) -> Vec<u8> {
+pub fn read_global_message(param: GlobalParamId) -> SysEx {
     command_message(&[
         OpCode::ReadParam.into(),
         0x00,
@@ -113,31 +114,31 @@ pub fn read_global_message(param: GlobalParamId) -> Vec<u8> {
     ])
 }
 
-pub fn write_global_message(param: GlobalParamId, value: u8) -> Vec<u8> {
+pub fn write_global_message(param: GlobalParamId, value: u8) -> SysEx {
     write_value_message(GLOBAL_PARAM_MARKER, param.into(), value)
 }
 
-pub fn recall_memory_message(slot: MemorySlot) -> Vec<u8> {
+pub fn recall_memory_message(slot: MemorySlot) -> SysEx {
     command_message(&[OpCode::RecallMemory.into(), slot.into()])
 }
 
-pub fn store_memory_message(slot: MemorySlot) -> Vec<u8> {
+pub fn store_memory_message(slot: MemorySlot) -> SysEx {
     command_message(&[OpCode::StoreMemory.into(), slot.into()])
 }
 
-pub fn identity_request_message() -> Vec<u8> {
-    Sysex::new(vec![IDENTITY_HEADER, 0x7F, 0x06, 0x01]).as_bytes()
+pub fn identity_request_message() -> SysEx {
+    sysex([IDENTITY_HEADER, 0x7F, 0x06, 0x01])
 }
 
-pub fn identity_reply_message(firmware: [u8; 4]) -> Vec<u8> {
+pub fn identity_reply_message(firmware: [u8; 4]) -> SysEx {
     let mut payload = vec![IDENTITY_HEADER, 0x00, 0x06, 0x02];
     payload.extend_from_slice(&SYSEX_MANUFACTURER_ID);
     payload.extend_from_slice(&[0x02, 0x00, 0x04, 0x02]);
     payload.extend_from_slice(&firmware);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn set_pad_live_color_message(pad: ControlId, color: PadColor) -> Vec<u8> {
+pub fn set_pad_live_color_message(pad: ControlId, color: PadColor) -> SysEx {
     write_param_message(ParamId::PadColorLive, pad, color.into())
 }
 
@@ -170,16 +171,16 @@ impl TryFrom<&[u8]> for DeviceStatus {
     type Error = DeviceStatusParseError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let sysex = Sysex::try_from(value)?;
+        let sysex = SysEx::try_from(value)?;
         DeviceStatus::try_from(sysex)
     }
 }
 
-impl TryFrom<Sysex> for DeviceStatus {
+impl TryFrom<SysEx> for DeviceStatus {
     type Error = DeviceStatusParseError;
 
-    fn try_from(value: Sysex) -> Result<Self, Self::Error> {
-        let payload = value.payload();
+    fn try_from(value: SysEx) -> Result<Self, Self::Error> {
+        let payload = value.bytes();
 
         if payload.first() == Some(&IDENTITY_HEADER) {
             return parse_identity_reply(payload);
@@ -389,7 +390,7 @@ impl Preset {
     ];
     const GENERIC_SHIFT_KNOB_CC: [u8; TOTAL_SHIFT_KNOBS] = [118, 119];
 
-    pub fn read_messages() -> Vec<Vec<u8>> {
+    pub fn read_messages() -> Vec<SysEx> {
         let mut messages = Vec::new();
 
         for id in ControlId::KNOBS.iter().chain(ControlId::SHIFT_KNOBS.iter()) {
@@ -425,7 +426,7 @@ impl Preset {
         messages
     }
 
-    pub fn send_messages(&self) -> Vec<Vec<u8>> {
+    pub fn send_messages(&self) -> Vec<SysEx> {
         let mut messages = Vec::new();
 
         for knob in self.knobs.knobs.iter().chain(self.knobs.shift_knobs.iter()) {
@@ -561,11 +562,11 @@ pub struct Global {
 }
 
 impl Global {
-    pub fn read_messages() -> Vec<Vec<u8>> {
+    pub fn read_messages() -> Vec<SysEx> {
         GlobalParamId::iter().map(read_global_message).collect()
     }
 
-    pub fn send_messages(&self) -> Vec<Vec<u8>> {
+    pub fn send_messages(&self) -> Vec<SysEx> {
         let raw = RawGlobal::from(self);
         GlobalParamId::iter()
             .zip(raw.as_bytes())
@@ -658,7 +659,7 @@ mod tests {
 
     #[test]
     fn test_read_param_message_format() {
-        let msg = read_param_message(ParamId::Mode, ControlId::Knob2);
+        let msg = read_param_message(ParamId::Mode, ControlId::Knob2).to_wire_bytes();
 
         assert_eq!(
             msg,
@@ -670,7 +671,8 @@ mod tests {
 
     #[test]
     fn test_write_param_message_format() {
-        let msg = write_param_message(ParamId::PadColor, ControlId::Pad1, PadColor::Yellow.into());
+        let msg = write_param_message(ParamId::PadColor, ControlId::Pad1, PadColor::Yellow.into())
+            .to_wire_bytes();
 
         assert_eq!(
             msg,
@@ -682,7 +684,7 @@ mod tests {
 
     #[test]
     fn test_read_global_message_format() {
-        let msg = read_global_message(GlobalParamId::KeyboardChannel);
+        let msg = read_global_message(GlobalParamId::KeyboardChannel).to_wire_bytes();
 
         assert_eq!(
             msg,
@@ -694,7 +696,7 @@ mod tests {
 
     #[test]
     fn test_write_global_message_format() {
-        let msg = write_global_message(GlobalParamId::KnobAcceleration, 0x02);
+        let msg = write_global_message(GlobalParamId::KnobAcceleration, 0x02).to_wire_bytes();
 
         assert_eq!(
             msg,
@@ -706,7 +708,7 @@ mod tests {
 
     #[test]
     fn test_recall_memory_message_format() {
-        let msg = recall_memory_message(MemorySlot::Slot2);
+        let msg = recall_memory_message(MemorySlot::Slot2).to_wire_bytes();
 
         assert_eq!(
             msg,
@@ -716,7 +718,7 @@ mod tests {
 
     #[test]
     fn test_store_memory_message_format() {
-        let msg = store_memory_message(MemorySlot::Slot8);
+        let msg = store_memory_message(MemorySlot::Slot8).to_wire_bytes();
 
         assert_eq!(
             msg,
@@ -727,14 +729,14 @@ mod tests {
     #[test]
     fn test_identity_request_message_format() {
         assert_eq!(
-            identity_request_message(),
+            identity_request_message().to_wire_bytes(),
             vec![0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7]
         );
     }
 
     #[test]
     fn test_set_pad_live_color_message_format() {
-        let msg = set_pad_live_color_message(ControlId::Pad16, PadColor::Cyan);
+        let msg = set_pad_live_color_message(ControlId::Pad16, PadColor::Cyan).to_wire_bytes();
 
         assert_eq!(
             msg,
@@ -801,7 +803,7 @@ mod tests {
         let firmware = [0x01, 0x00, 0x02, 0x05];
         let bytes = identity_reply_message(firmware);
 
-        let status = DeviceStatus::try_from(bytes.as_slice()).unwrap();
+        let status = DeviceStatus::try_from(bytes).unwrap();
         assert_eq!(
             status,
             DeviceStatus::IdentityReply(IdentityReply { firmware })
@@ -865,7 +867,7 @@ mod tests {
 
         let mut store = ParamStore::default();
         for message in preset.send_messages() {
-            let status = DeviceStatus::try_from(message.as_slice()).unwrap();
+            let status = DeviceStatus::try_from(message).unwrap();
             store.apply(&status);
         }
 
@@ -896,7 +898,7 @@ mod tests {
 
         let mut store = ParamStore::default();
         for message in global.send_messages() {
-            let status = DeviceStatus::try_from(message.as_slice()).unwrap();
+            let status = DeviceStatus::try_from(message).unwrap();
             store.apply(&status);
         }
 

--- a/midilab/src/manufacturer/arturia/minilab_mk2/error.rs
+++ b/midilab/src/manufacturer/arturia/minilab_mk2/error.rs
@@ -1,6 +1,6 @@
+use midi_io::SysExError;
 use num_enum::TryFromPrimitiveError;
 
-use crate::error::SysexParseError;
 use crate::manufacturer::arturia::minilab_mk2::control::value_kind::ButtonMode;
 use crate::manufacturer::arturia::minilab_mk2::control::value_kind::ControlChannel;
 use crate::manufacturer::arturia::minilab_mk2::control::value_kind::KnobAcceleration;
@@ -17,7 +17,7 @@ use crate::manufacturer::arturia::minilab_mk2::control::value_kind::VelocityCurv
 #[derive(Debug, thiserror::Error)]
 pub enum DeviceStatusParseError {
     #[error("invalid sysex: {0}")]
-    InvalidSysex(#[from] SysexParseError),
+    InvalidSysex(#[from] SysExError),
     #[error("invalid header")]
     InvalidHeader,
     #[error("invalid op code: {0}")]

--- a/midilab/src/manufacturer/korg/r3.rs
+++ b/midilab/src/manufacturer/korg/r3.rs
@@ -10,9 +10,10 @@ use raw::RawParameterChange;
 use raw::RawProgram;
 
 use crate::manufacturer::korg::SYSEX_MANUFACTURER_ID;
-use crate::sysex::Sysex;
+use crate::sysex::SysEx;
 use crate::sysex::pack_u7;
 use crate::sysex::pack_u14;
+use crate::sysex::sysex;
 use crate::sysex::unpack_u7;
 use crate::sysex::unpack_u14;
 
@@ -81,7 +82,7 @@ pub enum KorgR3Message {
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
     #[error("invalid sysex wrapper: {0}")]
-    Sysex(#[from] crate::error::SysexParseError),
+    Sysex(#[from] midi_io::SysExError),
     #[error("message too short: {0} bytes")]
     TooShort(usize),
     #[error("invalid manufacturer id: 0x{0:02X}")]
@@ -109,81 +110,81 @@ fn sysex_header(channel: u8, func_id: u8) -> Vec<u8> {
     ]
 }
 
-pub fn current_program_dump_request(channel: u8) -> Vec<u8> {
+pub fn current_program_dump_request(channel: u8) -> SysEx {
     let payload = sysex_header(channel, DeviceCommandId::CurrentProgramDumpRequest.into());
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn program_dump_request(channel: u8, program_no: u16) -> Vec<u8> {
+pub fn program_dump_request(channel: u8, program_no: u16) -> SysEx {
     let mut payload = sysex_header(channel, DeviceCommandId::ProgramDumpRequest.into());
     let [msb, lsb] = pack_u14(program_no);
     payload.push(lsb);
     payload.push(msb);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn current_formant_motion_dump_request(channel: u8) -> Vec<u8> {
+pub fn current_formant_motion_dump_request(channel: u8) -> SysEx {
     let payload = sysex_header(
         channel,
         DeviceCommandId::CurrentFormantMotionDumpRequest.into(),
     );
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn formant_motion_dump_request(channel: u8, motion_no: u8) -> Vec<u8> {
+pub fn formant_motion_dump_request(channel: u8, motion_no: u8) -> SysEx {
     let mut payload = sysex_header(channel, DeviceCommandId::FormantMotionDumpRequest.into());
     let [msb, lsb] = pack_u14(motion_no.into());
     payload.push(lsb);
     payload.push(msb);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn global_dump_request(channel: u8) -> Vec<u8> {
+pub fn global_dump_request(channel: u8) -> SysEx {
     let payload = sysex_header(channel, DeviceCommandId::GlobalDumpRequest.into());
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn program_write_request(channel: u8, dest_program_no: u16) -> Vec<u8> {
+pub fn program_write_request(channel: u8, dest_program_no: u16) -> SysEx {
     let mut payload = sysex_header(channel, DeviceCommandId::ProgramWriteRequest.into());
     let [msb, lsb] = pack_u14(dest_program_no);
     payload.push(lsb);
     payload.push(msb);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn formant_motion_write_request(channel: u8, dest_motion_no: u8) -> Vec<u8> {
+pub fn formant_motion_write_request(channel: u8, dest_motion_no: u8) -> SysEx {
     let mut payload = sysex_header(channel, DeviceCommandId::FormantMotionWriteRequest.into());
     let [msb, lsb] = pack_u14(dest_motion_no.into());
     payload.push(lsb);
     payload.push(msb);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn current_program_dump_message(channel: u8, program: &RawProgram) -> Vec<u8> {
+pub fn current_program_dump_message(channel: u8, program: &RawProgram) -> SysEx {
     let mut payload = sysex_header(channel, DeviceStatusId::CurrentProgramDump.into());
     let packed = pack_u7(bytemuck::bytes_of(program));
     payload.extend_from_slice(&packed);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn program_dump_message(channel: u8, program_no: u16, program: &RawProgram) -> Vec<u8> {
+pub fn program_dump_message(channel: u8, program_no: u16, program: &RawProgram) -> SysEx {
     let mut payload = sysex_header(channel, DeviceStatusId::ProgramDump.into());
     let [msb, lsb] = pack_u14(program_no);
     payload.push(lsb);
     payload.push(msb);
     let packed = pack_u7(bytemuck::bytes_of(program));
     payload.extend_from_slice(&packed);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn global_dump_message(channel: u8, global: &RawGlobal) -> Vec<u8> {
+pub fn global_dump_message(channel: u8, global: &RawGlobal) -> SysEx {
     let mut payload = sysex_header(channel, DeviceStatusId::GlobalDump.into());
     let packed = pack_u7(bytemuck::bytes_of(global));
     payload.extend_from_slice(&packed);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn current_formant_motion_dump_message(channel: u8, steps: &[RawFormantStep]) -> Vec<u8> {
+pub fn current_formant_motion_dump_message(channel: u8, steps: &[RawFormantStep]) -> SysEx {
     let mut payload = sysex_header(channel, DeviceStatusId::CurrentFormantMotionDump.into());
     let size = steps.len() as u16;
     let [size_hi, size_lo] = pack_u14(size);
@@ -193,14 +194,10 @@ pub fn current_formant_motion_dump_message(channel: u8, steps: &[RawFormantStep]
     payload.push(0x00);
     let packed = pack_u7(bytemuck::cast_slice(steps));
     payload.extend_from_slice(&packed);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn formant_motion_dump_message(
-    channel: u8,
-    motion_no: u8,
-    steps: &[RawFormantStep],
-) -> Vec<u8> {
+pub fn formant_motion_dump_message(channel: u8, motion_no: u8, steps: &[RawFormantStep]) -> SysEx {
     let mut payload = sysex_header(channel, DeviceStatusId::FormantMotionDump.into());
     let size = steps.len() as u16;
     let [size_hi, size_lo] = pack_u14(size);
@@ -210,29 +207,36 @@ pub fn formant_motion_dump_message(
     payload.push(0x00);
     let packed = pack_u7(bytemuck::cast_slice(steps));
     payload.extend_from_slice(&packed);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
-pub fn parameter_change_message(channel: u8, param_id: u16, sub_id: u16, value: u16) -> Vec<u8> {
+pub fn parameter_change_message(channel: u8, param_id: u16, sub_id: u16, value: u16) -> SysEx {
     let mut payload = sysex_header(channel, DeviceStatusId::ParameterChange.into());
     let [pp_msb, pp_lsb] = pack_u14(param_id);
     let [qq_msb, qq_lsb] = pack_u14(sub_id);
     let [vv_msb, vv_lsb] = pack_u14(value);
     payload.extend_from_slice(&[pp_lsb, pp_msb, qq_lsb, qq_msb, vv_lsb, vv_msb]);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
 impl TryFrom<&[u8]> for KorgR3Message {
     type Error = ParseError;
 
     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-        parse_sysex_impl(data)
+        KorgR3Message::try_from(&SysEx::try_from(data)?)
     }
 }
 
-fn parse_sysex_impl(data: &[u8]) -> Result<KorgR3Message, ParseError> {
-    let sysex = Sysex::try_from(data)?;
-    let payload = sysex.payload();
+impl TryFrom<&SysEx> for KorgR3Message {
+    type Error = ParseError;
+
+    fn try_from(sysex: &SysEx) -> Result<Self, Self::Error> {
+        parse_sysex_impl(sysex)
+    }
+}
+
+fn parse_sysex_impl(sysex: &SysEx) -> Result<KorgR3Message, ParseError> {
+    let payload = sysex.bytes();
 
     if payload.len() < 4 {
         return Err(ParseError::TooShort(payload.len()));
@@ -365,7 +369,7 @@ mod tests {
 
     #[test]
     fn test_current_program_dump_request_format() {
-        let msg = current_program_dump_request(0x00);
+        let msg = current_program_dump_request(0x00).to_wire_bytes();
         assert_eq!(msg[0], 0xF0);
         assert_eq!(msg[1], 0x42);
         assert_eq!(msg[2], 0x30);
@@ -377,7 +381,7 @@ mod tests {
 
     #[test]
     fn test_program_dump_request_format() {
-        let msg = program_dump_request(0x00, 0);
+        let msg = program_dump_request(0x00, 0).to_wire_bytes();
         assert_eq!(msg[0], 0xF0);
         assert_eq!(msg[1], 0x42);
         assert_eq!(msg[2], 0x30);
@@ -390,14 +394,14 @@ mod tests {
 
     #[test]
     fn test_program_dump_request_program_number() {
-        let msg = program_dump_request(0x00, 128);
+        let msg = program_dump_request(0x00, 128).to_wire_bytes();
         assert_eq!(msg[5], 0x00);
         assert_eq!(msg[6], 0x01);
     }
 
     #[test]
     fn test_global_dump_request_format() {
-        let msg = global_dump_request(0x00);
+        let msg = global_dump_request(0x00).to_wire_bytes();
         assert_eq!(msg[0], 0xF0);
         assert_eq!(msg[1], 0x42);
         assert_eq!(msg[2], 0x30);
@@ -408,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_formant_motion_dump_request_format() {
-        let msg = formant_motion_dump_request(0x00, 3);
+        let msg = formant_motion_dump_request(0x00, 3).to_wire_bytes();
         assert_eq!(msg[0], 0xF0);
         assert_eq!(msg[1], 0x42);
         assert_eq!(msg[2], 0x30);
@@ -421,7 +425,7 @@ mod tests {
 
     #[test]
     fn test_program_write_request_format() {
-        let msg = program_write_request(0x00, 5);
+        let msg = program_write_request(0x00, 5).to_wire_bytes();
         assert_eq!(msg[0], 0xF0);
         assert_eq!(msg[1], 0x42);
         assert_eq!(msg[2], 0x30);
@@ -434,7 +438,7 @@ mod tests {
 
     #[test]
     fn test_parameter_change_message_format() {
-        let msg = parameter_change_message(0x00, 0x01, 0x02, 0x03);
+        let msg = parameter_change_message(0x00, 0x01, 0x02, 0x03).to_wire_bytes();
         assert_eq!(msg[0], 0xF0);
         assert_eq!(msg[1], 0x42);
         assert_eq!(msg[2], 0x30);
@@ -452,7 +456,7 @@ mod tests {
     #[test]
     fn test_current_program_dump_message_starts_correctly() {
         let program = RawProgram::zeroed();
-        let msg = current_program_dump_message(0x00, &program);
+        let msg = current_program_dump_message(0x00, &program).to_wire_bytes();
 
         assert_eq!(msg[0], 0xF0);
         assert_eq!(msg[1], 0x42);
@@ -549,7 +553,7 @@ mod tests {
         program.name = *b"ParseTst";
 
         let msg = current_program_dump_message(0x00, &program);
-        let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+        let parsed = KorgR3Message::try_from(&msg).unwrap();
 
         match parsed {
             KorgR3Message::CurrentProgramDump(p) => {
@@ -565,7 +569,7 @@ mod tests {
         program.name = *b"SlotTest";
 
         let msg = program_dump_message(0x00, 42, &program);
-        let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+        let parsed = KorgR3Message::try_from(&msg).unwrap();
 
         match parsed {
             KorgR3Message::ProgramDump {
@@ -586,7 +590,7 @@ mod tests {
         global.transpose = 12;
 
         let msg = global_dump_message(0x00, &global);
-        let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+        let parsed = KorgR3Message::try_from(&msg).unwrap();
 
         match parsed {
             KorgR3Message::GlobalDump(g) => {
@@ -600,7 +604,7 @@ mod tests {
     #[test]
     fn test_parse_parameter_change() {
         let msg = parameter_change_message(0x00, 0x100, 0x02, 0x7F);
-        let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+        let parsed = KorgR3Message::try_from(&msg).unwrap();
 
         match parsed {
             KorgR3Message::ParameterChange(raw) => {
@@ -625,8 +629,8 @@ mod tests {
             (DeviceStatusId::DataFormatError, "DataFormatError"),
         ] {
             let payload = sysex_header(0x00, func_id.into());
-            let msg = Sysex::new(payload).as_bytes();
-            let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+            let msg = sysex(payload);
+            let parsed = KorgR3Message::try_from(&msg).unwrap();
 
             let name = format!("{parsed:?}");
             assert!(
@@ -667,8 +671,8 @@ mod tests {
     #[test]
     fn test_parse_empty_formant_dump_no_panic() {
         let payload = sysex_header(0x00, DeviceStatusId::CurrentFormantMotionDump.into());
-        let msg = Sysex::new(payload).as_bytes();
-        match KorgR3Message::try_from(msg.as_slice()).unwrap() {
+        let msg = sysex(payload);
+        match KorgR3Message::try_from(&msg).unwrap() {
             KorgR3Message::CurrentFormantMotionDump { steps, .. } => assert!(steps.is_empty()),
             other => panic!("expected CurrentFormantMotionDump, got {other:?}"),
         }
@@ -693,9 +697,9 @@ mod tests {
 
         let msg = current_program_dump_message(0x05, &program);
 
-        assert_eq!(msg[1], 0x42);
-        assert_eq!(msg[2], 0x35);
-        let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+        assert_eq!(msg.bytes()[0], 0x42);
+        assert_eq!(msg.bytes()[1], 0x35);
+        let parsed = KorgR3Message::try_from(&msg).unwrap();
         match parsed {
             KorgR3Message::CurrentProgramDump(p) => {
                 assert_eq!(p.name, *b"FullTrip");
@@ -723,9 +727,9 @@ mod tests {
 
         let msg = global_dump_message(0x0A, &global);
 
-        assert_eq!(msg[1], 0x42);
-        assert_eq!(msg[2], 0x3A);
-        let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+        assert_eq!(msg.bytes()[0], 0x42);
+        assert_eq!(msg.bytes()[1], 0x3A);
+        let parsed = KorgR3Message::try_from(&msg).unwrap();
         match parsed {
             KorgR3Message::GlobalDump(g) => {
                 assert_eq!(g.master_tune, 64);
@@ -749,7 +753,7 @@ mod tests {
         steps[2].bands[15] = 0x7F;
 
         let msg = current_formant_motion_dump_message(0x00, &steps);
-        let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+        let parsed = KorgR3Message::try_from(&msg).unwrap();
 
         match parsed {
             KorgR3Message::CurrentFormantMotionDump { size, steps: out } => {
@@ -771,7 +775,7 @@ mod tests {
         steps[2].bands[15] = 0x7F;
 
         let msg = formant_motion_dump_message(0x00, 5, &steps);
-        let parsed = KorgR3Message::try_from(msg.as_slice()).unwrap();
+        let parsed = KorgR3Message::try_from(&msg).unwrap();
 
         match parsed {
             KorgR3Message::FormantMotionDump {

--- a/midilab/src/manufacturer/korg/r3/live.rs
+++ b/midilab/src/manufacturer/korg/r3/live.rs
@@ -1,6 +1,7 @@
 use super::parameter_change_message;
 use super::raw::RawParameterChange;
 use super::wrappers::*;
+use crate::sysex::SysEx;
 use crate::sysex::unpack_u14;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -22,7 +23,7 @@ pub struct LiveParam {
 }
 
 impl LiveParam {
-    pub fn to_sysex(&self, channel: u8) -> Vec<u8> {
+    pub fn to_sysex(&self, channel: u8) -> SysEx {
         parameter_change_message(channel, self.addr.id, self.addr.sub, self.value)
     }
 }
@@ -885,7 +886,7 @@ mod tests {
             addr: ParamAddr::new(0x10, 0x32),
             value: 99,
         };
-        let msg = lp.to_sysex(0x00);
+        let msg = lp.to_sysex(0x00).to_wire_bytes();
         assert_eq!(&msg[0..5], &[0xF0, 0x42, 0x30, 0x7D, 0x41]);
         assert_eq!(&msg[5..11], &[0x10, 0x00, 0x32, 0x00, 0x63, 0x00]);
         assert_eq!(*msg.last().unwrap(), 0xF7);
@@ -902,7 +903,7 @@ mod tests {
             .find(|c| c.addr == ParamAddr::new(0x60, 0x00))
             .unwrap();
         assert_eq!(c.value, 200);
-        let msg = c.to_sysex(0);
+        let msg = c.to_sysex(0).to_wire_bytes();
         assert_eq!(&msg[9..11], &[0x48, 0x01]);
     }
 
@@ -922,7 +923,7 @@ mod tests {
 
         for lp in program_params(&src) {
             let bytes = lp.to_sysex(0x00);
-            let parsed = KorgR3Message::try_from(bytes.as_slice()).expect("valid sysex");
+            let parsed = KorgR3Message::try_from(&bytes).expect("valid sysex");
             let raw = match parsed {
                 KorgR3Message::ParameterChange(r) => r,
                 other => panic!("expected ParameterChange, got {other:?}"),
@@ -948,12 +949,11 @@ mod tests {
     fn unmapped_address_is_ignored() {
         let mut p = prog();
         let raw = match crate::manufacturer::korg::r3::KorgR3Message::try_from(
-            LiveParam {
+            &LiveParam {
                 addr: ParamAddr::new(0x7F, 0x7F),
                 value: 1,
             }
-            .to_sysex(0)
-            .as_slice(),
+            .to_sysex(0),
         )
         .unwrap()
         {

--- a/midilab/src/manufacturer/nektar/impact_lx_plus.rs
+++ b/midilab/src/manufacturer/nektar/impact_lx_plus.rs
@@ -47,7 +47,8 @@ use crate::manufacturer::nektar::impact_lx_plus::value_kind::ContinuousKind;
 use crate::manufacturer::nektar::impact_lx_plus::value_kind::ControlChannel;
 use crate::manufacturer::nektar::impact_lx_plus::value_kind::MidiChannel;
 use crate::midi::Value;
-use crate::sysex::Sysex;
+use crate::sysex::SysEx;
+use crate::sysex::sysex;
 
 pub mod control;
 pub mod error;
@@ -154,7 +155,7 @@ pub fn checksum(body: &[u8]) -> u8 {
     !sum & 0x7F
 }
 
-fn command_message(object: ObjectType, section: u8, id: u8, params: &[(u8, u8)]) -> Vec<u8> {
+fn command_message(object: ObjectType, section: u8, id: u8, params: &[(u8, u8)]) -> SysEx {
     let mut body = vec![object.into(), section, id];
     for (index, (param, value)) in params.iter().enumerate() {
         if index > 0 {
@@ -166,7 +167,7 @@ fn command_message(object: ObjectType, section: u8, id: u8, params: &[(u8, u8)])
 
     let mut payload = SYSEX_COMMAND_HEADER.to_vec();
     payload.extend_from_slice(&body);
-    Sysex::new(payload).as_bytes()
+    sysex(payload)
 }
 
 fn control_params(value: &RawControl) -> Vec<(u8, u8)> {
@@ -181,7 +182,7 @@ pub fn preset_control_message(
     preset: PresetId,
     control: PresetControlId,
     value: &RawControl,
-) -> Vec<u8> {
+) -> SysEx {
     command_message(
         ObjectType::PresetControl,
         preset.into(),
@@ -190,7 +191,7 @@ pub fn preset_control_message(
     )
 }
 
-pub fn pad_message(map: PadMapId, pad: PadId, value: &RawPad) -> Vec<u8> {
+pub fn pad_message(map: PadMapId, pad: PadId, value: &RawPad) -> SysEx {
     let params: Vec<(u8, u8)> = PAD_PARAMS
         .into_iter()
         .map(u8::from)
@@ -201,11 +202,11 @@ pub fn pad_message(map: PadMapId, pad: PadId, value: &RawPad) -> Vec<u8> {
 
 /// Global settings are single-TLV messages whose param id is the setting id
 /// itself (message id is always `0x01`).
-pub fn global_setting_message(setting: GlobalSettingId, value: u8) -> Vec<u8> {
+pub fn global_setting_message(setting: GlobalSettingId, value: u8) -> SysEx {
     command_message(ObjectType::Global, 0x00, 0x01, &[(setting.into(), value)])
 }
 
-pub fn global_control_message(control: GlobalControlId, value: &RawControl) -> Vec<u8> {
+pub fn global_control_message(control: GlobalControlId, value: &RawControl) -> SysEx {
     command_message(
         ObjectType::Global,
         0x00,
@@ -237,7 +238,7 @@ pub enum DeviceStatus {
 }
 
 impl DeviceStatus {
-    pub fn message(&self) -> Vec<u8> {
+    pub fn message(&self) -> SysEx {
         match self {
             DeviceStatus::PresetControl {
                 preset,
@@ -314,16 +315,16 @@ impl TryFrom<&[u8]> for DeviceStatus {
     type Error = DeviceStatusParseError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let sysex = Sysex::try_from(value)?;
+        let sysex = SysEx::try_from(value)?;
         DeviceStatus::try_from(sysex)
     }
 }
 
-impl TryFrom<Sysex> for DeviceStatus {
+impl TryFrom<SysEx> for DeviceStatus {
     type Error = DeviceStatusParseError;
 
-    fn try_from(value: Sysex) -> Result<Self, Self::Error> {
-        let payload = value.payload();
+    fn try_from(value: SysEx) -> Result<Self, Self::Error> {
+        let payload = value.bytes();
 
         if !payload.starts_with(&SYSEX_COMMAND_HEADER) {
             return Err(DeviceStatusParseError::InvalidHeader);
@@ -586,7 +587,7 @@ impl Preset {
     ///
     /// The device applies them silently to stored memory; the live state
     /// updates the next time the preset is loaded from the panel.
-    pub fn send_messages(&self, preset: PresetId) -> Vec<Vec<u8>> {
+    pub fn send_messages(&self, preset: PresetId) -> Vec<SysEx> {
         let raw = RawPreset::from(self);
         let mut messages = Vec::with_capacity(TOTAL_PRESET_CONTROLS);
         for (id, value) in PresetControlId::FADERS.iter().zip(raw.faders.iter()) {
@@ -683,7 +684,7 @@ impl PadMap {
     }
 
     /// The 8 stored-memory write messages for this pad map, in dump order.
-    pub fn send_messages(&self, map: PadMapId) -> Vec<Vec<u8>> {
+    pub fn send_messages(&self, map: PadMapId) -> Vec<SysEx> {
         let raw = RawPadMap::from(self);
         PadId::ALL
             .iter()
@@ -737,7 +738,7 @@ pub struct GlobalSettings {
 
 impl GlobalSettings {
     /// Writes to global settings apply to the live device state instantly.
-    pub fn send_messages(&self) -> Vec<Vec<u8>> {
+    pub fn send_messages(&self) -> Vec<SysEx> {
         let raw = RawGlobalSettings::from(self);
         GlobalSettingId::iter()
             .zip(raw.values)
@@ -794,7 +795,7 @@ pub struct GlobalControls {
 
 impl GlobalControls {
     /// Writes to global controls apply to the live device state instantly.
-    pub fn send_messages(&self) -> Vec<Vec<u8>> {
+    pub fn send_messages(&self) -> Vec<SysEx> {
         let raw = RawGlobalControls::from(self);
         let mut messages = Vec::with_capacity(TOTAL_GLOBAL_CONTROLS);
         for (id, value) in GlobalControlId::TRANSPORT.iter().zip(raw.transport.iter()) {
@@ -897,7 +898,7 @@ pub struct Dump {
 impl Dump {
     /// All 182 write messages in canonical dump order. Replaying them to the
     /// device restores its memory byte-perfectly.
-    pub fn to_messages(&self) -> Vec<Vec<u8>> {
+    pub fn to_messages(&self) -> Vec<SysEx> {
         let mut messages = Vec::with_capacity(DUMP_MESSAGE_COUNT);
         for (id, preset) in PresetId::iter().zip(self.presets.iter()) {
             messages.extend(preset.send_messages(id));
@@ -1028,13 +1029,14 @@ mod tests {
             min: 0,
             max: 127,
         };
-        let msg = preset_control_message(PresetId::Preset1, PresetControlId::Fader1, &value);
+        let msg = preset_control_message(PresetId::Preset1, PresetControlId::Fader1, &value)
+            .to_wire_bytes();
         assert_eq!(msg, FACTORY_FADER1);
     }
 
     #[test]
     fn test_global_setting_message_format() {
-        let msg = global_setting_message(GlobalSettingId::MidiChannel, 0x01);
+        let msg = global_setting_message(GlobalSettingId::MidiChannel, 0x01).to_wire_bytes();
         assert_eq!(msg, FACTORY_MIDI_CHANNEL);
     }
 
@@ -1047,7 +1049,7 @@ mod tests {
             min: 0,
             max: 127,
         };
-        let msg = global_control_message(GlobalControlId::ModWheel, &value);
+        let msg = global_control_message(GlobalControlId::ModWheel, &value).to_wire_bytes();
         assert_eq!(msg, FACTORY_MOD_WHEEL);
     }
 
@@ -1061,7 +1063,7 @@ mod tests {
             max: 127,
             note: 36,
         };
-        let msg = pad_message(PadMapId::Map1, PadId::Pad1, &value);
+        let msg = pad_message(PadMapId::Map1, PadId::Pad1, &value).to_wire_bytes();
         assert_eq!(msg, FACTORY_PAD1);
     }
 
@@ -1139,7 +1141,7 @@ mod tests {
     fn test_device_status_message_round_trip() {
         let dump = Dump::default();
         for message in dump.to_messages() {
-            let status = DeviceStatus::try_from(message.as_slice()).unwrap();
+            let status = DeviceStatus::try_from(message.clone()).unwrap();
             assert_eq!(status.message(), message);
         }
     }
@@ -1173,7 +1175,7 @@ mod tests {
         assert!(assembler.is_empty());
 
         for message in dump.to_messages() {
-            let status = DeviceStatus::try_from(message.as_slice()).unwrap();
+            let status = DeviceStatus::try_from(message).unwrap();
             assembler.apply(&status);
         }
 

--- a/midilab/src/manufacturer/nektar/impact_lx_plus/error.rs
+++ b/midilab/src/manufacturer/nektar/impact_lx_plus/error.rs
@@ -1,6 +1,6 @@
+use midi_io::SysExError;
 use num_enum::TryFromPrimitiveError;
 
-use crate::error::SysexParseError;
 use crate::manufacturer::nektar::impact_lx_plus::value_kind::ButtonKind;
 use crate::manufacturer::nektar::impact_lx_plus::value_kind::ContinuousKind;
 use crate::manufacturer::nektar::impact_lx_plus::value_kind::ControlChannel;
@@ -9,7 +9,7 @@ use crate::manufacturer::nektar::impact_lx_plus::value_kind::MidiChannel;
 #[derive(Debug, thiserror::Error)]
 pub enum DeviceStatusParseError {
     #[error("invalid sysex: {0}")]
-    InvalidSysex(#[from] SysexParseError),
+    InvalidSysex(#[from] SysExError),
     #[error("invalid header")]
     InvalidHeader,
     #[error("invalid length: {0}")]

--- a/midilab/src/sysex.rs
+++ b/midilab/src/sysex.rs
@@ -1,4 +1,5 @@
-use crate::error::SysexParseError;
+use bytemuck::Pod;
+pub use midi_io::SysEx;
 
 pub fn pack_u14(val: u16) -> [u8; 2] {
     let high = ((val >> 7) & 0x7F) as u8;
@@ -47,50 +48,32 @@ pub fn unpack_u7(data: &[u8]) -> Vec<u8> {
     out
 }
 
-#[derive(Debug, Clone)]
-pub struct Sysex(midi_io::SysEx);
+pub fn sysex(payload: impl AsRef<[u8]>) -> SysEx {
+    SysEx::new(payload.as_ref()).expect("sysex payload must be non-empty and 7-bit clean")
+}
 
-use bytemuck::Pod;
+pub fn from_header_and_body<H: Pod, B: AsRef<[u8]>>(header: &H, body: B) -> SysEx {
+    let mut payload = bytemuck::bytes_of(header).to_vec();
+    payload.extend_from_slice(body.as_ref());
+    sysex(payload)
+}
 
-impl Sysex {
-    pub fn new(payload: Vec<u8>) -> Self {
-        Self(
-            midi_io::SysEx::new(&payload).expect("sysex payload must be non-empty and 7-bit clean"),
-        )
-    }
+pub trait SysExPreview {
+    fn preview(&self) -> String;
+}
 
-    pub fn payload(&self) -> &[u8] {
-        self.0.bytes()
-    }
-
-    pub fn as_bytes(&self) -> Vec<u8> {
-        self.0.to_wire_bytes()
-    }
-
-    pub fn from_header_and_body<H: Pod, B: AsRef<[u8]>>(header: &H, body: B) -> Self {
-        let mut payload = bytemuck::bytes_of(header).to_vec();
-        payload.extend_from_slice(body.as_ref());
-        Self::new(payload)
-    }
-
-    pub fn from_header_and_body_as_bytes<H: Pod, B: AsRef<[u8]>>(header: &H, body: B) -> Vec<u8> {
-        let sysex = Self::from_header_and_body(header, body);
-        sysex.as_bytes()
-    }
-
-    pub fn preview(&self) -> String {
+impl SysExPreview for SysEx {
+    fn preview(&self) -> String {
         const CHUNK_HEAD_LEN: usize = 4;
         const CHUNK_TAIL_LEN: usize = 4;
         const CHUNK_TOTAL_LEN: usize = CHUNK_HEAD_LEN + CHUNK_TAIL_LEN;
 
-        if self.payload().len() <= CHUNK_TOTAL_LEN {
-            let s = self.payload();
-            format!("{s:02x?}, {} bytes", self.payload().len())
+        let payload = self.bytes();
+        if payload.len() <= CHUNK_TOTAL_LEN {
+            format!("{payload:02x?}, {} bytes", payload.len())
         } else {
-            let chunk_head = self.payload()[0..CHUNK_HEAD_LEN].to_vec();
-            let chunk_tail = self.payload()
-                [(self.payload().len() - CHUNK_TAIL_LEN)..self.payload().len()]
-                .to_vec();
+            let chunk_head = &payload[0..CHUNK_HEAD_LEN];
+            let chunk_tail = &payload[payload.len() - CHUNK_TAIL_LEN..];
 
             let hs: Vec<String> = chunk_head.iter().map(|i| format!("{i:02x}")).collect();
             let hs = hs.join(", ");
@@ -98,33 +81,27 @@ impl Sysex {
             let ts: Vec<String> = chunk_tail.iter().map(|i| format!("{i:02x}")).collect();
             let ts = ts.join(", ");
 
-            format!("[{hs}, ..., {ts}], {} bytes", self.payload().len())
+            format!("[{hs}, ..., {ts}], {} bytes", payload.len())
         }
-    }
-}
-
-impl TryFrom<&[u8]> for Sysex {
-    type Error = SysexParseError;
-
-    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Sysex(midi_io::SysEx::try_from(data)?))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use midi_io::SysExError;
+
     use super::*;
 
     #[test]
     fn test_sysex_preview_short_payload() {
-        let s = Sysex::new(vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        let s = sysex([0, 1, 2, 3, 4, 5, 6, 7]);
 
         assert_eq!(&s.preview(), "[00, 01, 02, 03, 04, 05, 06, 07], 8 bytes");
     }
 
     #[test]
     fn test_sysex_preview_long_payload() {
-        let s = Sysex::new(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
+        let s = sysex([0, 1, 2, 3, 4, 5, 6, 7, 8]);
 
         assert_eq!(
             &s.preview(),
@@ -212,11 +189,10 @@ mod tests {
     }
 
     #[test]
-    fn test_sysex_as_bytes() {
-        let payload = vec![0x47, 0x00, 0x35];
-        let sysex = Sysex::new(payload);
+    fn test_sysex_to_wire_bytes() {
+        let s = sysex([0x47, 0x00, 0x35]);
 
-        let bytes = sysex.as_bytes();
+        let bytes = s.to_wire_bytes();
         assert_eq!(bytes[0], 0xf0);
         assert_eq!(bytes[1], 0x47);
         assert_eq!(bytes[2], 0x00);
@@ -228,64 +204,49 @@ mod tests {
     #[test]
     fn test_sysex_try_from_vec_valid() {
         let data = vec![0xf0, 0x47, 0x00, 0x35, 0xf7];
-        let sysex = Sysex::try_from(data.as_slice()).unwrap();
+        let s = SysEx::try_from(data.as_slice()).unwrap();
 
-        assert_eq!(sysex.payload(), &[0x47, 0x00, 0x35]);
+        assert_eq!(s.bytes(), &[0x47, 0x00, 0x35]);
     }
 
     #[test]
     fn test_sysex_try_from_empty_payload_is_err() {
         let data = vec![0xf0, 0xf7];
-        let result = Sysex::try_from(data.as_slice()).unwrap_err();
+        let result = SysEx::try_from(data.as_slice()).unwrap_err();
 
-        assert!(matches!(
-            result,
-            SysexParseError::Codec(midi_io::SysExError::EmptyBody)
-        ));
+        assert!(matches!(result, SysExError::EmptyBody));
     }
 
     #[test]
     fn test_sysex_try_from_invalid_start_byte() {
         let data = vec![0x00, 0x47, 0x00, 0x35, 0xf7];
-        let result = Sysex::try_from(data.as_slice()).unwrap_err();
+        let result = SysEx::try_from(data.as_slice()).unwrap_err();
 
-        assert!(matches!(
-            result,
-            SysexParseError::Codec(midi_io::SysExError::MissingStart)
-        ))
+        assert!(matches!(result, SysExError::MissingStart))
     }
 
     #[test]
     fn test_sysex_try_from_invalid_end_byte() {
         let data = vec![0xf0, 0x47, 0x00, 0x35, 0x00];
-        let result = Sysex::try_from(data.as_slice()).unwrap_err();
+        let result = SysEx::try_from(data.as_slice()).unwrap_err();
 
-        assert!(matches!(
-            result,
-            SysexParseError::Codec(midi_io::SysExError::Unterminated)
-        ))
+        assert!(matches!(result, SysExError::Unterminated))
     }
 
     #[test]
     fn test_sysex_try_from_empty_data() {
         let data: Vec<u8> = vec![];
-        let result = Sysex::try_from(data.as_slice()).unwrap_err();
+        let result = SysEx::try_from(data.as_slice()).unwrap_err();
 
-        assert!(matches!(
-            result,
-            SysexParseError::Codec(midi_io::SysExError::MissingStart)
-        ));
+        assert!(matches!(result, SysExError::MissingStart));
     }
 
     #[test]
     fn test_sysex_try_from_single_byte() {
         let data = vec![0xf0];
-        let result = Sysex::try_from(data.as_slice()).unwrap_err();
+        let result = SysEx::try_from(data.as_slice()).unwrap_err();
 
-        assert!(matches!(
-            result,
-            SysexParseError::Codec(midi_io::SysExError::Unterminated)
-        ));
+        assert!(matches!(result, SysExError::Unterminated));
     }
 
     #[test]
@@ -338,10 +299,10 @@ mod tests {
     #[test]
     fn test_sysex_round_trip() {
         let original_payload = vec![0x47, 0x00, 0x35, 0x10, 0x08, 0x33];
-        let sysex = Sysex::new(original_payload.clone());
-        let bytes = sysex.as_bytes();
-        let reconstructed = Sysex::try_from(bytes.as_slice()).unwrap();
+        let s = sysex(&original_payload);
+        let bytes = s.to_wire_bytes();
+        let reconstructed = SysEx::try_from(bytes.as_slice()).unwrap();
 
-        assert_eq!(reconstructed.payload(), &original_payload);
+        assert_eq!(reconstructed.bytes(), &original_payload);
     }
 }

--- a/midilab/tests/hil_arturia_minilab_mk2.rs
+++ b/midilab/tests/hil_arturia_minilab_mk2.rs
@@ -24,7 +24,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 const WRITE_PACING: Duration = Duration::from_millis(2);
 const PORT_NAME_FRAGMENT: &str = "MiniLab";
 
-async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>>) {
+async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<SysEx>) {
     let client = Client::new("minilab_mk2").await.unwrap();
 
     let destinations = client.destinations().await.unwrap();
@@ -49,11 +49,11 @@ async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>
     println!("matched source port: {:?}", in_port.name());
     let conn_in = client.connect_source(in_port).await.unwrap();
 
-    let (tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let (tx, mut rx) = mpsc::unbounded_channel::<SysEx>();
     tokio::spawn(async move {
         let mut sysex = conn_in.into_sysex();
         while let Some(timed) = sysex.recv().await {
-            let _ = tx.send(timed.payload.to_wire_bytes());
+            let _ = tx.send(timed.payload);
         }
     });
 
@@ -63,28 +63,27 @@ async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>
     (conn_out, rx)
 }
 
-async fn send_bytes(conn: &DestinationConnection, bytes: &[u8]) {
-    let sysex = SysEx::try_from(bytes).unwrap();
-    conn.send_sysex(&sysex).await.unwrap();
+async fn send(conn: &DestinationConnection, sysex: &SysEx) {
+    conn.send_sysex(sysex).await.unwrap();
 }
 
-async fn recv_bytes(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>) -> Vec<u8> {
+async fn recv_bytes(rx: &mut mpsc::UnboundedReceiver<SysEx>) -> SysEx {
     timeout(TIMEOUT, rx.recv()).await.unwrap().unwrap()
 }
 
-async fn try_recv_bytes(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>) -> Option<Vec<u8>> {
+async fn try_recv_bytes(rx: &mut mpsc::UnboundedReceiver<SysEx>) -> Option<SysEx> {
     timeout(PROBE_TIMEOUT, rx.recv()).await.ok().flatten()
 }
 
 async fn read_param(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
     param: ParamId,
     control: ControlId,
 ) -> u8 {
-    send_bytes(conn, &read_param_message(param, control)).await;
+    send(conn, &read_param_message(param, control)).await;
     let data = recv_bytes(rx).await;
-    match DeviceStatus::try_from(data.as_slice()).unwrap() {
+    match DeviceStatus::try_from(data).unwrap() {
         DeviceStatus::ParamValue(pv) => {
             assert_eq!(pv.param, param);
             assert_eq!(pv.control, control);
@@ -96,13 +95,13 @@ async fn read_param(
 
 async fn read_full_preset(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
 ) -> Preset {
     let mut store = ParamStore::default();
     for message in Preset::read_messages() {
-        send_bytes(conn, &message).await;
+        send(conn, &message).await;
         let data = recv_bytes(rx).await;
-        let status = DeviceStatus::try_from(data.as_slice()).unwrap();
+        let status = DeviceStatus::try_from(data).unwrap();
         store.apply(&status);
     }
     store.try_into_preset().unwrap()
@@ -110,11 +109,11 @@ async fn read_full_preset(
 
 async fn write_full_preset(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
     preset: &Preset,
 ) {
     for message in preset.send_messages() {
-        send_bytes(conn, &message).await;
+        send(conn, &message).await;
         tokio::time::sleep(WRITE_PACING).await;
     }
     while rx.try_recv().is_ok() {}
@@ -125,11 +124,11 @@ async fn write_full_preset(
 async fn probe_identity() {
     let (conn, mut rx) = midi_setup().await;
 
-    send_bytes(&conn, &identity_request_message()).await;
+    send(&conn, &identity_request_message()).await;
     let data = recv_bytes(&mut rx).await;
     println!("identity reply: {data:02X?}");
 
-    let status = DeviceStatus::try_from(data.as_slice()).unwrap();
+    let status = DeviceStatus::try_from(data).unwrap();
     let DeviceStatus::IdentityReply(reply) = status else {
         panic!("expected identity reply, got {status:?}");
     };
@@ -144,7 +143,7 @@ async fn probe_write_ack_behavior() {
     let original = read_param(&conn, &mut rx, ParamId::Data1, ControlId::Knob2).await;
     println!("knob2 cc: {original}");
 
-    send_bytes(
+    send(
         &conn,
         &write_param_message(ParamId::Data1, ControlId::Knob2, original),
     )
@@ -161,10 +160,9 @@ async fn probe_shift_and_padbank_control_ids() {
     let (conn, mut rx) = midi_setup().await;
 
     for candidate in [0x2Eu8, 0x2F, 0x55, 0x56] {
-        let message = vec![
-            0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x01, 0x00, 0x01, candidate, 0xF7,
-        ];
-        send_bytes(&conn, &message).await;
+        let message =
+            SysEx::new(&[0x00, 0x20, 0x6B, 0x7F, 0x42, 0x01, 0x00, 0x01, candidate]).unwrap();
+        send(&conn, &message).await;
         match try_recv_bytes(&mut rx).await {
             Some(reply) => println!("control {candidate:#04x} replied: {reply:02X?}"),
             None => println!("control {candidate:#04x} no reply"),
@@ -180,7 +178,7 @@ async fn probe_pad_color_params() {
     let stored = read_param(&conn, &mut rx, ParamId::PadColor, ControlId::Pad1).await;
     println!("pad1 stored color (0x11): {stored:#04x}");
 
-    send_bytes(
+    send(
         &conn,
         &set_pad_live_color_message(ControlId::Pad1, PadColor::Cyan),
     )
@@ -203,7 +201,7 @@ async fn param_round_trip() {
     let original = read_param(&conn, &mut rx, ParamId::Data1, ControlId::Knob2).await;
     let mutated = if original == 0x7F { 0x00 } else { original + 1 };
 
-    send_bytes(
+    send(
         &conn,
         &write_param_message(ParamId::Data1, ControlId::Knob2, mutated),
     )
@@ -214,7 +212,7 @@ async fn param_round_trip() {
     let loaded = read_param(&conn, &mut rx, ParamId::Data1, ControlId::Knob2).await;
     assert_eq!(loaded, mutated);
 
-    send_bytes(
+    send(
         &conn,
         &write_param_message(ParamId::Data1, ControlId::Knob2, original),
     )
@@ -246,24 +244,24 @@ async fn global_round_trip() {
 
     let mut store = ParamStore::default();
     for message in Global::read_messages() {
-        send_bytes(&conn, &message).await;
+        send(&conn, &message).await;
         let data = recv_bytes(&mut rx).await;
-        store.apply(&DeviceStatus::try_from(data.as_slice()).unwrap());
+        store.apply(&DeviceStatus::try_from(data).unwrap());
     }
     let original = store.try_into_global().unwrap();
     println!("global: {original:?}");
 
     for message in original.send_messages() {
-        send_bytes(&conn, &message).await;
+        send(&conn, &message).await;
         tokio::time::sleep(WRITE_PACING).await;
     }
     while rx.try_recv().is_ok() {}
 
     let mut store = ParamStore::default();
     for message in Global::read_messages() {
-        send_bytes(&conn, &message).await;
+        send(&conn, &message).await;
         let data = recv_bytes(&mut rx).await;
-        store.apply(&DeviceStatus::try_from(data.as_slice()).unwrap());
+        store.apply(&DeviceStatus::try_from(data).unwrap());
     }
     let reloaded = store.try_into_global().unwrap();
 
@@ -277,7 +275,7 @@ async fn probe_memory_recall() {
 
     let working = read_full_preset(&conn, &mut rx).await;
 
-    send_bytes(&conn, &recall_memory_message(MemorySlot::Slot2)).await;
+    send(&conn, &recall_memory_message(MemorySlot::Slot2)).await;
     tokio::time::sleep(Duration::from_millis(100)).await;
     while rx.try_recv().is_ok() {}
 

--- a/midilab/tests/hil_korg_r3.rs
+++ b/midilab/tests/hil_korg_r3.rs
@@ -29,7 +29,7 @@ use tokio::time::timeout;
 const TIMEOUT: Duration = Duration::from_secs(5);
 const CHANNEL: u8 = 0x00;
 
-async fn connect(name: &str) -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>>) {
+async fn connect(name: &str) -> (DestinationConnection, mpsc::UnboundedReceiver<SysEx>) {
     let client = Client::new(name).await.unwrap();
 
     let sound_port = client
@@ -50,40 +50,39 @@ async fn connect(name: &str) -> (DestinationConnection, mpsc::UnboundedReceiver<
         .expect("no R3 KBD/KNOB");
     let conn_in = client.connect_source(&kbd_port).await.unwrap();
 
-    let (tx, rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let (tx, rx) = mpsc::unbounded_channel::<SysEx>();
     tokio::spawn(async move {
         let mut sysex = conn_in.into_sysex();
         while let Some(timed) = sysex.recv().await {
-            let _ = tx.send(timed.payload.to_wire_bytes());
+            let _ = tx.send(timed.payload);
         }
     });
 
     (conn, rx)
 }
 
-async fn send_bytes(conn: &DestinationConnection, bytes: &[u8]) {
-    let sysex = SysEx::try_from(bytes).unwrap();
-    conn.send_sysex(&sysex).await.unwrap();
+async fn send(conn: &DestinationConnection, sysex: &SysEx) {
+    conn.send_sysex(sysex).await.unwrap();
 }
 
-async fn recv(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>, dur: Duration) -> Vec<u8> {
+async fn recv(rx: &mut mpsc::UnboundedReceiver<SysEx>, dur: Duration) -> SysEx {
     timeout(dur, rx.recv())
         .await
         .expect("timed out waiting for sysex response")
         .expect("channel closed")
 }
 
-async fn try_recv(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>, dur: Duration) -> Option<Vec<u8>> {
+async fn try_recv(rx: &mut mpsc::UnboundedReceiver<SysEx>, dur: Duration) -> Option<SysEx> {
     timeout(dur, rx.recv()).await.ok().flatten()
 }
 
 async fn read_global(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
 ) -> RawGlobal {
-    send_bytes(conn, &global_dump_request(CHANNEL)).await;
+    send(conn, &global_dump_request(CHANNEL)).await;
     let data = recv(rx, TIMEOUT).await;
-    match KorgR3Message::try_from(data.as_slice()).expect("parse global dump") {
+    match KorgR3Message::try_from(&data).expect("parse global dump") {
         KorgR3Message::GlobalDump(g) => *g,
         other => panic!("expected GlobalDump, got {other:?}"),
     }
@@ -91,11 +90,11 @@ async fn read_global(
 
 async fn read_current_program(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
 ) -> RawProgram {
-    send_bytes(conn, &current_program_dump_request(CHANNEL)).await;
+    send(conn, &current_program_dump_request(CHANNEL)).await;
     let data = recv(rx, TIMEOUT).await;
-    match KorgR3Message::try_from(data.as_slice()).expect("parse program dump") {
+    match KorgR3Message::try_from(&data).expect("parse program dump") {
         KorgR3Message::CurrentProgramDump(p) => *p,
         other => panic!("expected CurrentProgramDump, got {other:?}"),
     }
@@ -103,12 +102,12 @@ async fn read_current_program(
 
 async fn read_slot(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
     slot: u16,
 ) -> RawProgram {
-    send_bytes(conn, &program_dump_request(CHANNEL, slot)).await;
+    send(conn, &program_dump_request(CHANNEL, slot)).await;
     let data = recv(rx, TIMEOUT).await;
-    match KorgR3Message::try_from(data.as_slice()).expect("parse slot dump") {
+    match KorgR3Message::try_from(&data).expect("parse slot dump") {
         KorgR3Message::ProgramDump {
             program_no,
             program,
@@ -122,13 +121,13 @@ async fn read_slot(
 
 async fn read_motion(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
     motion_no: u8,
 ) -> (u16, Vec<RawFormantStep>) {
-    send_bytes(conn, &formant_motion_dump_request(CHANNEL, motion_no)).await;
+    send(conn, &formant_motion_dump_request(CHANNEL, motion_no)).await;
     loop {
         let data = recv(rx, TIMEOUT).await;
-        match KorgR3Message::try_from(data.as_slice()).expect("parse motion dump") {
+        match KorgR3Message::try_from(&data).expect("parse motion dump") {
             KorgR3Message::FormantMotionDump {
                 motion_no: n,
                 size,
@@ -145,20 +144,20 @@ async fn read_motion(
 
 async fn write_motion(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
     motion_no: u8,
     steps: &[RawFormantStep],
 ) {
-    send_bytes(conn, &current_formant_motion_dump_message(CHANNEL, steps)).await;
+    send(conn, &current_formant_motion_dump_message(CHANNEL, steps)).await;
     expect_data_load_completed(rx).await;
-    send_bytes(conn, &formant_motion_write_request(CHANNEL, motion_no)).await;
+    send(conn, &formant_motion_write_request(CHANNEL, motion_no)).await;
     expect_data_load_completed(rx).await;
 }
 
-async fn expect_data_load_completed(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>) {
+async fn expect_data_load_completed(rx: &mut mpsc::UnboundedReceiver<SysEx>) {
     loop {
         let data = recv(rx, TIMEOUT).await;
-        match KorgR3Message::try_from(data.as_slice()).expect("parse ack") {
+        match KorgR3Message::try_from(&data).expect("parse ack") {
             KorgR3Message::DataLoadCompleted | KorgR3Message::WriteCompleted => return,
             KorgR3Message::ParameterChange(_) => continue,
             other => panic!("expected DataLoadCompleted, got {other:?}"),
@@ -174,7 +173,7 @@ async fn global_dump_discovery() {
     eprintln!("Scanning channels 0-15...");
     let mut found_ch: Option<u8> = None;
     for try_ch in 0u8..=15 {
-        send_bytes(&conn, &global_dump_request(try_ch)).await;
+        send(&conn, &global_dump_request(try_ch)).await;
         if let Some(data) = try_recv(&mut rx, Duration::from_secs(5)).await {
             eprintln!(
                 "  *** RESPONSE ch={try_ch}: {} bytes {:02X?} ***",
@@ -194,11 +193,11 @@ async fn global_dump_discovery() {
     }
 
     let ch = found_ch.unwrap_or(ch);
-    send_bytes(&conn, &global_dump_request(ch)).await;
+    send(&conn, &global_dump_request(ch)).await;
     let data = recv(&mut rx, TIMEOUT).await;
     eprintln!("Raw: {} bytes", data.len());
 
-    match KorgR3Message::try_from(data.as_slice()).expect("parse global") {
+    match KorgR3Message::try_from(&data).expect("parse global") {
         KorgR3Message::GlobalDump(g) => {
             eprintln!("master_tune = {}", g.master_tune);
             assert!(g.master_tune <= 100);
@@ -212,11 +211,11 @@ async fn global_dump_discovery() {
 async fn current_program_dump_discovery() {
     let (conn, mut rx) = connect("r3-pd").await;
 
-    send_bytes(&conn, &current_program_dump_request(CHANNEL)).await;
+    send(&conn, &current_program_dump_request(CHANNEL)).await;
     let data = recv(&mut rx, TIMEOUT).await;
     eprintln!("Raw: {} bytes", data.len());
 
-    match KorgR3Message::try_from(data.as_slice()).expect("parse program") {
+    match KorgR3Message::try_from(&data).expect("parse program") {
         KorgR3Message::CurrentProgramDump(p) => {
             let name = std::str::from_utf8(&p.name).unwrap_or("<non-utf8>");
             eprintln!("name = {:?}", name);
@@ -248,13 +247,13 @@ async fn global_round_trip() {
     let mut modified = original;
     modified.master_tune = new_tune;
 
-    send_bytes(&conn, &global_dump_message(CHANNEL, &modified)).await;
+    send(&conn, &global_dump_message(CHANNEL, &modified)).await;
     expect_data_load_completed(&mut rx).await;
 
     let readback = read_global(&conn, &mut rx).await;
     assert_eq!(readback.master_tune, new_tune);
 
-    send_bytes(&conn, &global_dump_message(CHANNEL, &original)).await;
+    send(&conn, &global_dump_message(CHANNEL, &original)).await;
     expect_data_load_completed(&mut rx).await;
 
     let restored = read_global(&conn, &mut rx).await;
@@ -276,13 +275,13 @@ async fn program_round_trip() {
     let mut modified = original;
     modified.name = *b"HILTEST ";
 
-    send_bytes(&conn, &current_program_dump_message(CHANNEL, &modified)).await;
+    send(&conn, &current_program_dump_message(CHANNEL, &modified)).await;
     expect_data_load_completed(&mut rx).await;
 
     let readback = read_current_program(&conn, &mut rx).await;
     assert_eq!(&readback.name, b"HILTEST ");
 
-    send_bytes(&conn, &current_program_dump_message(CHANNEL, &original)).await;
+    send(&conn, &current_program_dump_message(CHANNEL, &original)).await;
     expect_data_load_completed(&mut rx).await;
 
     let restored = read_current_program(&conn, &mut rx).await;
@@ -299,7 +298,7 @@ async fn parameter_change_program() {
     let orig_name0 = original.name[0];
 
     let new_name0: u8 = if orig_name0 != b'Z' { b'Z' } else { b'Y' };
-    send_bytes(
+    send(
         &conn,
         &parameter_change_message(CHANNEL, 0x00, 0x00, new_name0 as u16),
     )
@@ -312,7 +311,7 @@ async fn parameter_change_program() {
         "parameter change did not update current program name[0]"
     );
 
-    send_bytes(&conn, &current_program_dump_message(CHANNEL, &original)).await;
+    send(&conn, &current_program_dump_message(CHANNEL, &original)).await;
     expect_data_load_completed(&mut rx).await;
     let restored = read_current_program(&conn, &mut rx).await;
     assert_eq!(bytemuck::bytes_of(&restored), bytemuck::bytes_of(&original));
@@ -325,11 +324,11 @@ async fn program_dump_slot() {
     let (conn, mut rx) = connect("r3-sl").await;
 
     for slot in [0, 1, 32, 64] {
-        send_bytes(&conn, &program_dump_request(CHANNEL, slot)).await;
+        send(&conn, &program_dump_request(CHANNEL, slot)).await;
         let data = recv(&mut rx, TIMEOUT).await;
         eprintln!("Slot {slot}: {} bytes", data.len());
 
-        match KorgR3Message::try_from(data.as_slice()).expect("parse slot dump") {
+        match KorgR3Message::try_from(&data).expect("parse slot dump") {
             KorgR3Message::ProgramDump {
                 program_no,
                 program: p,
@@ -360,21 +359,18 @@ async fn program_write_slot() {
     let mut modified = original;
     modified.name = *b"WRITESL ";
 
-    send_bytes(&conn, &current_program_dump_message(CHANNEL, &modified)).await;
+    send(&conn, &current_program_dump_message(CHANNEL, &modified)).await;
     expect_data_load_completed(&mut rx).await;
 
     let target_slot: u16 = 0;
-    send_bytes(&conn, &program_write_request(CHANNEL, target_slot)).await;
+    send(&conn, &program_write_request(CHANNEL, target_slot)).await;
 
-    match KorgR3Message::try_from(recv(&mut rx, TIMEOUT).await.as_slice()).expect("parse write ack")
-    {
+    match KorgR3Message::try_from(&recv(&mut rx, TIMEOUT).await).expect("parse write ack") {
         KorgR3Message::DataLoadCompleted | KorgR3Message::WriteCompleted => {
             eprintln!("write to slot {target_slot} succeeded");
 
-            send_bytes(&conn, &program_dump_request(CHANNEL, target_slot)).await;
-            match KorgR3Message::try_from(recv(&mut rx, TIMEOUT).await.as_slice())
-                .expect("read back")
-            {
+            send(&conn, &program_dump_request(CHANNEL, target_slot)).await;
+            match KorgR3Message::try_from(&recv(&mut rx, TIMEOUT).await).expect("read back") {
                 KorgR3Message::ProgramDump {
                     program_no,
                     program: p,
@@ -385,15 +381,13 @@ async fn program_write_slot() {
                 other => panic!("expected ProgramDump on read-back, got {other:?}"),
             }
 
-            send_bytes(&conn, &current_program_dump_message(CHANNEL, &original)).await;
+            send(&conn, &current_program_dump_message(CHANNEL, &original)).await;
             expect_data_load_completed(&mut rx).await;
-            send_bytes(&conn, &program_write_request(CHANNEL, target_slot)).await;
+            send(&conn, &program_write_request(CHANNEL, target_slot)).await;
             expect_data_load_completed(&mut rx).await;
 
-            send_bytes(&conn, &program_dump_request(CHANNEL, target_slot)).await;
-            match KorgR3Message::try_from(recv(&mut rx, TIMEOUT).await.as_slice())
-                .expect("read restored")
-            {
+            send(&conn, &program_dump_request(CHANNEL, target_slot)).await;
+            match KorgR3Message::try_from(&recv(&mut rx, TIMEOUT).await).expect("read restored") {
                 KorgR3Message::ProgramDump {
                     program: restored, ..
                 } => {
@@ -454,7 +448,7 @@ async fn program_model_round_trip() {
         diffs.len()
     );
 
-    send_bytes(&conn, &current_program_dump_message(CHANNEL, &raw2)).await;
+    send(&conn, &current_program_dump_message(CHANNEL, &raw2)).await;
     expect_data_load_completed(&mut rx).await;
     let readback = read_current_program(&conn, &mut rx).await;
     let prog_rb = Program::try_from(readback).expect("decode device readback");
@@ -464,7 +458,7 @@ async fn program_model_round_trip() {
         "modeled parameters did not survive a real device round-trip"
     );
 
-    send_bytes(&conn, &current_program_dump_message(CHANNEL, &original)).await;
+    send(&conn, &current_program_dump_message(CHANNEL, &original)).await;
     expect_data_load_completed(&mut rx).await;
     let restored = read_current_program(&conn, &mut rx).await;
     assert_eq!(bytemuck::bytes_of(&restored), orig_bytes.as_slice());
@@ -506,7 +500,7 @@ async fn global_model_round_trip() {
         return;
     }
     let raw2: RawGlobal = *bytemuck::from_bytes(&encoded);
-    send_bytes(&conn, &global_dump_message(CHANNEL, &raw2)).await;
+    send(&conn, &global_dump_message(CHANNEL, &raw2)).await;
     expect_data_load_completed(&mut rx).await;
     let readback = read_global(&conn, &mut rx).await;
     assert_eq!(
@@ -514,7 +508,7 @@ async fn global_model_round_trip() {
         encoded.as_slice(),
         "global did not survive device round-trip"
     );
-    send_bytes(&conn, &global_dump_message(CHANNEL, &original)).await;
+    send(&conn, &global_dump_message(CHANNEL, &original)).await;
     expect_data_load_completed(&mut rx).await;
     eprintln!("Global model round-trip OK");
 }
@@ -525,9 +519,9 @@ async fn tempo_encoding_probe() {
     let (conn, mut rx) = connect("r3-tp").await;
 
     for slot in [0u16, 1, 16, 32, 64, 99, 127] {
-        send_bytes(&conn, &program_dump_request(CHANNEL, slot)).await;
+        send(&conn, &program_dump_request(CHANNEL, slot)).await;
         let data = recv(&mut rx, TIMEOUT).await;
-        match KorgR3Message::try_from(data.as_slice()).expect("parse slot dump") {
+        match KorgR3Message::try_from(&data).expect("parse slot dump") {
             KorgR3Message::ProgramDump { program: p, .. } => {
                 let raw = bytemuck::bytes_of(&*p);
                 let lsb = raw[444] as u16;
@@ -552,11 +546,11 @@ async fn tempo_encoding_probe() {
 async fn formant_motion_dump() {
     let (conn, mut rx) = connect("r3-mo").await;
 
-    send_bytes(&conn, &current_formant_motion_dump_request(CHANNEL)).await;
+    send(&conn, &current_formant_motion_dump_request(CHANNEL)).await;
     let data = recv(&mut rx, TIMEOUT).await;
     eprintln!("current formant motion: {} bytes", data.len());
 
-    match KorgR3Message::try_from(data.as_slice()).expect("parse formant") {
+    match KorgR3Message::try_from(&data).expect("parse formant") {
         KorgR3Message::CurrentFormantMotionDump { size, steps } => {
             eprintln!(
                 "  SIZE={size}  steps={}  ~{:.2}s",
@@ -656,11 +650,10 @@ async fn editor_write_path_fix_slot0_name() {
         "typed encode changed bytes other than the name"
     );
 
-    send_bytes(&conn, &current_program_dump_message(CHANNEL, &fixed)).await;
+    send(&conn, &current_program_dump_message(CHANNEL, &fixed)).await;
     expect_data_load_completed(&mut rx).await;
-    send_bytes(&conn, &program_write_request(CHANNEL, 0)).await;
-    match KorgR3Message::try_from(recv(&mut rx, TIMEOUT).await.as_slice()).expect("parse write ack")
-    {
+    send(&conn, &program_write_request(CHANNEL, 0)).await;
+    match KorgR3Message::try_from(&recv(&mut rx, TIMEOUT).await).expect("parse write ack") {
         KorgR3Message::DataLoadCompleted | KorgR3Message::WriteCompleted => {}
         KorgR3Message::DataLoadError => panic!("write REJECTED — memory protect is ON"),
         other => panic!("expected write ack, got {other:?}"),

--- a/midilab/tests/hil_nektar_impact_lx_plus.rs
+++ b/midilab/tests/hil_nektar_impact_lx_plus.rs
@@ -27,7 +27,7 @@ const DUMP_START_TIMEOUT: Duration = Duration::from_secs(120);
 const DUMP_MESSAGE_TIMEOUT: Duration = Duration::from_secs(10);
 const WRITE_PACING: Duration = Duration::from_millis(2);
 
-async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>>) {
+async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<SysEx>) {
     let client = Client::new("impact_lx_plus").await.unwrap();
 
     let destinations = client.destinations().await.unwrap();
@@ -52,11 +52,11 @@ async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>
     println!("matched source port: {:?}", in_port.name());
     let conn_in = client.connect_source(in_port).await.unwrap();
 
-    let (tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let (tx, mut rx) = mpsc::unbounded_channel::<SysEx>();
     tokio::spawn(async move {
         let mut sysex = conn_in.into_sysex();
         while let Some(timed) = sysex.recv().await {
-            let _ = tx.send(timed.payload.to_wire_bytes());
+            let _ = tx.send(timed.payload);
         }
     });
 
@@ -66,12 +66,11 @@ async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>
     (conn_out, rx)
 }
 
-async fn send_bytes(conn: &DestinationConnection, bytes: &[u8]) {
-    let sysex = SysEx::try_from(bytes).unwrap();
-    conn.send_sysex(&sysex).await.unwrap();
+async fn send(conn: &DestinationConnection, sysex: &SysEx) {
+    conn.send_sysex(sysex).await.unwrap();
 }
 
-async fn capture_dump(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>) -> Vec<Vec<u8>> {
+async fn capture_dump(rx: &mut mpsc::UnboundedReceiver<SysEx>) -> Vec<SysEx> {
     println!();
     println!(">>> On the keyboard: press [Setup], then the key labeled *Memory Dump* (G2).");
     println!(">>> The display reads SYS while the dump is sent.");
@@ -100,10 +99,10 @@ async fn capture_dump(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>) -> Vec<Vec<u8>>
     messages
 }
 
-fn assemble(messages: &[Vec<u8>]) -> Dump {
+fn assemble(messages: &[SysEx]) -> Dump {
     let mut assembler = DumpAssembler::default();
     for message in messages {
-        let status = DeviceStatus::try_from(message.as_slice()).unwrap();
+        let status = DeviceStatus::try_from(message.clone()).unwrap();
         assembler.apply(&status);
     }
     assert!(assembler.is_complete());
@@ -121,7 +120,7 @@ async fn dump_model_round_trip() {
     let captured = capture_dump(&mut rx).await;
 
     for (index, message) in captured.iter().enumerate() {
-        let status = DeviceStatus::try_from(message.as_slice()).unwrap();
+        let status = DeviceStatus::try_from(message.clone()).unwrap();
         assert_eq!(
             &status.message(),
             message,
@@ -150,7 +149,7 @@ async fn dump_restore_round_trip() {
         original.len()
     );
     for message in dump.to_messages() {
-        send_bytes(&conn, &message).await;
+        send(&conn, &message).await;
         tokio::time::sleep(WRITE_PACING).await;
     }
     while rx.try_recv().is_ok() {}

--- a/midilab/tests/hil_tests.rs
+++ b/midilab/tests/hil_tests.rs
@@ -19,7 +19,7 @@ use tokio::time::timeout;
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 
-async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>>) {
+async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<SysEx>) {
     let client = Client::new("mpd226").await.unwrap();
 
     let out_port = client
@@ -40,11 +40,11 @@ async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>
         .unwrap();
     let conn_in = client.connect_source(&in_port).await.unwrap();
 
-    let (tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let (tx, mut rx) = mpsc::unbounded_channel::<SysEx>();
     tokio::spawn(async move {
         let mut sysex = conn_in.into_sysex();
         while let Some(timed) = sysex.recv().await {
-            let _ = tx.send(timed.payload.to_wire_bytes());
+            let _ = tx.send(timed.payload);
         }
     });
 
@@ -54,12 +54,11 @@ async fn midi_setup() -> (DestinationConnection, mpsc::UnboundedReceiver<Vec<u8>
     (conn_out, rx)
 }
 
-async fn send_bytes(conn: &DestinationConnection, bytes: &[u8]) {
-    let sysex = SysEx::try_from(bytes).unwrap();
-    conn.send_sysex(&sysex).await.unwrap();
+async fn send(conn: &DestinationConnection, sysex: &SysEx) {
+    conn.send_sysex(sysex).await.unwrap();
 }
 
-async fn recv_bytes(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>) -> Vec<u8> {
+async fn recv_bytes(rx: &mut mpsc::UnboundedReceiver<SysEx>) -> SysEx {
     timeout(TIMEOUT, rx.recv()).await.unwrap().unwrap()
 }
 
@@ -69,10 +68,10 @@ async fn preset_round_trip() {
     let (conn, mut rx) = midi_setup().await;
 
     let original = {
-        send_bytes(&conn, &dump_preset_from_device(0x00)).await;
+        send(&conn, &dump_preset_from_device(0x00)).await;
         let res = {
             let data = recv_bytes(&mut rx).await;
-            DeviceStatus::try_from(data.as_slice()).unwrap()
+            DeviceStatus::try_from(data).unwrap()
         };
         match res {
             DeviceStatus::PresetData(p) => *p,
@@ -94,10 +93,10 @@ async fn preset_round_trip() {
     {
         let preset: &Preset = &mutated;
         let raw = RawPreset::from(preset);
-        send_bytes(&conn, &write_preset_to_device(&raw)).await;
+        send(&conn, &write_preset_to_device(&raw)).await;
         let res = {
             let data = recv_bytes(&mut rx).await;
-            DeviceStatus::try_from(data.as_slice()).unwrap()
+            DeviceStatus::try_from(data).unwrap()
         };
         match res {
             DeviceStatus::ReceivedPresetAck(_) => {}
@@ -105,10 +104,10 @@ async fn preset_round_trip() {
         }
     };
     let loaded = {
-        send_bytes(&conn, &dump_preset_from_device(0x00)).await;
+        send(&conn, &dump_preset_from_device(0x00)).await;
         let res = {
             let data = recv_bytes(&mut rx).await;
-            DeviceStatus::try_from(data.as_slice()).unwrap()
+            DeviceStatus::try_from(data).unwrap()
         };
         match res {
             DeviceStatus::PresetData(p) => *p,
@@ -129,10 +128,10 @@ async fn preset_round_trip() {
     {
         let preset: &Preset = &original;
         let raw = RawPreset::from(preset);
-        send_bytes(&conn, &write_preset_to_device(&raw)).await;
+        send(&conn, &write_preset_to_device(&raw)).await;
         let res = {
             let data = recv_bytes(&mut rx).await;
-            DeviceStatus::try_from(data.as_slice()).unwrap()
+            DeviceStatus::try_from(data).unwrap()
         };
         match res {
             DeviceStatus::ReceivedPresetAck(_) => {}
@@ -140,10 +139,10 @@ async fn preset_round_trip() {
         }
     };
     let restored = {
-        send_bytes(&conn, &dump_preset_from_device(0x00)).await;
+        send(&conn, &dump_preset_from_device(0x00)).await;
         let res = {
             let data = recv_bytes(&mut rx).await;
-            DeviceStatus::try_from(data.as_slice()).unwrap()
+            DeviceStatus::try_from(data).unwrap()
         };
         match res {
             DeviceStatus::PresetData(p) => *p,
@@ -160,14 +159,14 @@ async fn preset_round_trip() {
 
 async fn send_global(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
     global: &Global,
 ) {
     let raw = RawGlobal::from(global);
     for msg in raw.global_send_messages() {
-        send_bytes(conn, &msg).await;
+        send(conn, &msg).await;
         let data = recv_bytes(rx).await;
-        let res = DeviceStatus::try_from(data.as_slice()).unwrap();
+        let res = DeviceStatus::try_from(data).unwrap();
         match res {
             DeviceStatus::GlobalParamAck(_) => {}
             _ => panic!("wrong variant"),
@@ -177,11 +176,11 @@ async fn send_global(
 
 async fn read_global(
     conn: &DestinationConnection,
-    rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    rx: &mut mpsc::UnboundedReceiver<SysEx>,
 ) -> Global {
-    send_bytes(conn, &dump_global_from_device()).await;
+    send(conn, &dump_global_from_device()).await;
     let data = recv_bytes(rx).await;
-    let res = DeviceStatus::try_from(data.as_slice()).unwrap();
+    let res = DeviceStatus::try_from(data).unwrap();
     match res {
         DeviceStatus::GlobalData(g) => *g,
         _ => panic!("wrong variant"),

--- a/midilab/tests/impact_lx_plus_factory_dump.rs
+++ b/midilab/tests/impact_lx_plus_factory_dump.rs
@@ -47,6 +47,10 @@ fn default_dump_encodes_byte_perfect_factory_dump() {
 
     assert_eq!(encoded.len(), captured.len());
     for (index, (encoded, captured)) in encoded.iter().zip(captured.iter()).enumerate() {
-        assert_eq!(encoded, captured, "message {index} differs");
+        assert_eq!(
+            &encoded.to_wire_bytes(),
+            captured,
+            "message {index} differs"
+        );
     }
 }

--- a/nektar_impact_lx_plus_editor/src/main.rs
+++ b/nektar_impact_lx_plus_editor/src/main.rs
@@ -182,8 +182,7 @@ async fn connect_input(client: &Client, app_tx: UnboundedSender<AppMsg>) -> Resu
         let mut sysex = conn.into_sysex();
         let mut assembler = DumpAssembler::default();
         while let Some(timed) = sysex.recv().await {
-            let bytes = timed.payload.to_wire_bytes();
-            let status = match DeviceStatus::try_from(bytes.as_slice()) {
+            let status = match DeviceStatus::try_from(timed.payload) {
                 Ok(status) => status,
                 Err(e) => {
                     let _ = app_tx.send(AppMsg::UserError(UserError::Parse(e.to_string())));
@@ -214,19 +213,16 @@ async fn connect_input(client: &Client, app_tx: UnboundedSender<AppMsg>) -> Resu
     Ok(())
 }
 
-async fn send_bytes(output: &DestinationConnection, bytes: &[u8]) -> Result<(), MidiError> {
-    let sysex = SysEx::try_from(bytes).map_err(|e| MidiError::OutputConnection(e.to_string()))?;
+async fn send(output: &DestinationConnection, sysex: &SysEx) -> Result<(), MidiError> {
     output
-        .send_sysex(&sysex)
+        .send_sysex(sysex)
         .await
         .map_err(|e| MidiError::OutputConnection(e.to_string()))
 }
 
-async fn send_all(output: &DestinationConnection, messages: Vec<Vec<u8>>) -> Result<(), UserError> {
+async fn send_all(output: &DestinationConnection, messages: Vec<SysEx>) -> Result<(), UserError> {
     for message in messages {
-        send_bytes(output, &message)
-            .await
-            .map_err(UserError::Midi)?;
+        send(output, &message).await.map_err(UserError::Midi)?;
         tokio::time::sleep(WRITE_PACING).await;
     }
     Ok(())

--- a/sim/src/manufacturer/akai/akai_mpd226.rs
+++ b/sim/src/manufacturer/akai/akai_mpd226.rs
@@ -10,17 +10,18 @@ use midilab::manufacturer::akai::mpd226::control::value_kind::PresetSlot;
 use midilab::manufacturer::akai::mpd226::raw::RawGlobal;
 use midilab::manufacturer::akai::mpd226::raw::RawHeader;
 use midilab::manufacturer::akai::mpd226::raw::RawPreset;
-use midilab::sysex::Sysex;
+use midilab::sysex::SysExPreview;
+use midilab::sysex::from_header_and_body;
 use midilab::sysex::pack_u14;
 use thiserror::Error;
 use tokio::sync::oneshot;
 
 pub enum SimMsg {
-    SysexReceived(Sysex),
+    SysexReceived(SysEx),
 }
 
 pub enum SimEffect {
-    SendSysex(Sysex),
+    SendSysex(SysEx),
     Noop,
 }
 
@@ -60,7 +61,7 @@ impl Mpd226Sim {
 
                         let preset = &self.presets[slot as usize];
                         let raw = RawPreset::from(preset);
-                        SimEffect::SendSysex(Sysex::new(dump_preset(&raw)))
+                        SimEffect::SendSysex(dump_preset(&raw))
                     }
                     DeviceCommandId::WritePreset => {
                         let raw_preset: RawPreset =
@@ -75,12 +76,12 @@ impl Mpd226Sim {
                         let slot = preset.settings.slot;
                         println!("decoded write preset command for slot {slot}");
                         self.presets[slot as usize] = preset;
-                        SimEffect::SendSysex(Sysex::new(ack_preset(slot)))
+                        SimEffect::SendSysex(ack_preset(slot))
                     }
                     DeviceCommandId::DumpGlobal => {
                         println!("decoded dump global command");
                         let raw = RawGlobal::from(&self.global);
-                        SimEffect::SendSysex(Sysex::new(dump_global(&raw)))
+                        SimEffect::SendSysex(dump_global(&raw))
                     }
                     DeviceCommandId::WriteGlobal => {
                         let addr = device_msg_payload.data[2];
@@ -94,7 +95,7 @@ impl Mpd226Sim {
                                     "decoded write global command: addr: {addr}, value: {value}, idx: {idx}"
                                 );
                                 self.global = g;
-                                SimEffect::SendSysex(Sysex::new(ack_global(addr)))
+                                SimEffect::SendSysex(ack_global(addr))
                             }
                             Err(e) => {
                                 eprintln!("{}", e);
@@ -108,7 +109,7 @@ impl Mpd226Sim {
     }
 }
 
-fn ack_preset(slot: PresetSlot) -> Vec<u8> {
+fn ack_preset(slot: PresetSlot) -> SysEx {
     let header = RawHeader {
         mfg_id: SYSEX_MANUFACTURER_ID,
         _unknown: 0,
@@ -117,19 +118,14 @@ fn ack_preset(slot: PresetSlot) -> Vec<u8> {
         length: pack_u14(2),
     };
 
-    let sysex = midilab::sysex::Sysex::from_header_and_body(&header, [slot as u8, 0x00]);
-    sysex.payload().to_vec()
+    from_header_and_body(&header, [slot as u8, 0x00])
 }
 
-fn dump_preset(raw: &RawPreset) -> Vec<u8> {
-    let sysex = midilab::sysex::Sysex::from_header_and_body(
-        &RawHeader::write_preset(),
-        bytemuck::bytes_of(raw),
-    );
-    sysex.payload().to_vec()
+fn dump_preset(raw: &RawPreset) -> SysEx {
+    from_header_and_body(&RawHeader::write_preset(), bytemuck::bytes_of(raw))
 }
 
-fn dump_global(raw: &RawGlobal) -> Vec<u8> {
+fn dump_global(raw: &RawGlobal) -> SysEx {
     let length = pack_u14(14);
     let header = RawHeader {
         mfg_id: SYSEX_MANUFACTURER_ID,
@@ -138,13 +134,12 @@ fn dump_global(raw: &RawGlobal) -> Vec<u8> {
         cmd: DeviceStatusId::WriteGlobal as u8,
         length,
     };
-    let sysex = midilab::sysex::Sysex::from_header_and_body(&header, [0x0B, 0x00, 0x01]);
-    let mut payload = sysex.payload().to_vec();
-    payload.extend_from_slice(bytemuck::bytes_of(raw));
-    payload
+    let mut body = vec![0x0B, 0x00, 0x01];
+    body.extend_from_slice(bytemuck::bytes_of(raw));
+    from_header_and_body(&header, body)
 }
 
-fn ack_global(addr: u8) -> Vec<u8> {
+fn ack_global(addr: u8) -> SysEx {
     let header = RawHeader {
         mfg_id: SYSEX_MANUFACTURER_ID,
         _unknown: 0,
@@ -152,8 +147,7 @@ fn ack_global(addr: u8) -> Vec<u8> {
         cmd: DeviceStatusId::GlobalAck as u8,
         length: pack_u14(4),
     };
-    let sysex = midilab::sysex::Sysex::from_header_and_body(&header, [0x01, 0x00, addr, 0x00]);
-    sysex.payload().to_vec()
+    from_header_and_body(&header, [0x01, 0x00, addr, 0x00])
 }
 
 #[derive(Debug, Error)]
@@ -203,7 +197,7 @@ impl SimRunner {
                     break;
                 }
                 Some(timed) = self.sysex_in.recv() => {
-                    let sysex_in = Sysex::new(timed.payload.bytes().to_vec());
+                    let sysex_in = timed.payload;
                     println!("received sysex payload: {}", sysex_in.preview());
 
                     let effect = self.sim.update(SimMsg::SysexReceived(sysex_in));
@@ -212,13 +206,8 @@ impl SimRunner {
                         SimEffect::SendSysex(sysex_out) => {
                             println!("sending sysex payload: {}", sysex_out.preview());
 
-                            match SysEx::new(sysex_out.payload()) {
-                                Ok(sysex) => {
-                                    if let Err(e) = self.out_port.send_sysex(&sysex).await {
-                                        eprintln!("MIDI send error: {e}");
-                                    }
-                                }
-                                Err(e) => eprintln!("MIDI send error: {e}"),
+                            if let Err(e) = self.out_port.send_sysex(&sysex_out).await {
+                                eprintln!("MIDI send error: {e}");
                             }
                         }
                         SimEffect::Noop => {
@@ -274,7 +263,7 @@ mod tests {
             SimEffect::Noop => panic!("expected SendSysex"),
         };
 
-        let status = DeviceStatus::try_from(response.as_bytes().as_slice()).unwrap();
+        let status = DeviceStatus::try_from(response).unwrap();
         match status {
             DeviceStatus::ReceivedPresetAck(ack) => {
                 assert_eq!(ack.slot, preset.settings.slot)
@@ -290,8 +279,7 @@ mod tests {
     #[test]
     fn test_sim_update_dump_preset() {
         let mut sim = Mpd226Sim::default();
-        let request_bytes = dump_preset_from_device(PresetSlot::RAM as u8);
-        let sysex = Sysex::try_from(request_bytes.as_slice()).unwrap();
+        let sysex = dump_preset_from_device(PresetSlot::RAM as u8);
 
         let effect = sim.update(SimMsg::SysexReceived(sysex));
 
@@ -300,15 +288,14 @@ mod tests {
             _ => panic!("expected SendSysex"),
         };
 
-        let status = DeviceStatus::try_from(response.as_bytes().as_slice()).unwrap();
+        let status = DeviceStatus::try_from(response).unwrap();
         assert!(matches!(status, DeviceStatus::PresetData(_)));
     }
 
     #[test]
     fn test_sim_update_dump_global() {
         let mut sim = Mpd226Sim::default();
-        let request_bytes = dump_global_from_device();
-        let sysex = Sysex::try_from(request_bytes.as_slice()).unwrap();
+        let sysex = dump_global_from_device();
 
         let effect = sim.update(SimMsg::SysexReceived(sysex));
 
@@ -317,7 +304,7 @@ mod tests {
             _ => panic!("expected SendSysex"),
         };
 
-        let status = DeviceStatus::try_from(response.as_bytes().as_slice()).unwrap();
+        let status = DeviceStatus::try_from(response).unwrap();
         assert!(matches!(status, DeviceStatus::GlobalData(_)));
     }
 
@@ -328,8 +315,7 @@ mod tests {
         let mut sim = Mpd226Sim::default();
         let addr = GlobalParamCmdId::LcdContrast as u8;
         let value = 75u8;
-        let request_bytes = write_global_param_to_device(addr, value);
-        let sysex = Sysex::try_from(request_bytes.as_slice()).unwrap();
+        let sysex = write_global_param_to_device(addr, value);
 
         let effect = sim.update(SimMsg::SysexReceived(sysex));
 
@@ -338,7 +324,7 @@ mod tests {
             _ => panic!("expected SendSysex"),
         };
 
-        let status = DeviceStatus::try_from(response.as_bytes().as_slice()).unwrap();
+        let status = DeviceStatus::try_from(response).unwrap();
         match status {
             DeviceStatus::GlobalParamAck(ack) => assert_eq!(ack.addr as u8, addr),
             _ => panic!("expected GlobalParamAck"),

--- a/sim/src/manufacturer/arturia/arturia_minilab_mk2.rs
+++ b/sim/src/manufacturer/arturia/arturia_minilab_mk2.rs
@@ -8,7 +8,7 @@ use midilab::manufacturer::arturia::minilab_mk2::Preset;
 use midilab::manufacturer::arturia::minilab_mk2::SYSEX_COMMAND_HEADER;
 use midilab::manufacturer::arturia::minilab_mk2::identity_reply_message;
 use midilab::manufacturer::arturia::minilab_mk2::write_value_message;
-use midilab::sysex::Sysex;
+use midilab::sysex::SysExPreview;
 use thiserror::Error;
 use tokio::sync::oneshot;
 
@@ -17,11 +17,11 @@ const SIM_FIRMWARE: [u8; 4] = [0x01, 0x00, 0x02, 0x05];
 const IDENTITY_REQUEST_PAYLOAD: [u8; 4] = [0x7E, 0x7F, 0x06, 0x01];
 
 pub enum SimMsg {
-    SysexReceived(Sysex),
+    SysexReceived(SysEx),
 }
 
 pub enum SimEffect {
-    SendSysex(Sysex),
+    SendSysex(SysEx),
     Noop,
 }
 
@@ -48,8 +48,8 @@ fn seeded_store() -> ParamStore {
         .chain(Global::default().send_messages());
 
     for message in messages {
-        let status = DeviceStatus::try_from(message.as_slice())
-            .expect("default preset/global messages must parse");
+        let status =
+            DeviceStatus::try_from(message).expect("default preset/global messages must parse");
         store.apply(&status);
     }
 
@@ -64,14 +64,12 @@ impl MinilabMk2Sim {
         }
     }
 
-    fn handle_sysex(&mut self, sysex: &Sysex) -> SimEffect {
-        let payload = sysex.payload();
+    fn handle_sysex(&mut self, sysex: &SysEx) -> SimEffect {
+        let payload = sysex.bytes();
 
         if payload == IDENTITY_REQUEST_PAYLOAD {
             println!("decoded identity request");
-            return SimEffect::SendSysex(
-                Sysex::try_from(identity_reply_message(SIM_FIRMWARE).as_slice()).unwrap(),
-            );
+            return SimEffect::SendSysex(identity_reply_message(SIM_FIRMWARE));
         }
 
         if !payload.starts_with(&SYSEX_COMMAND_HEADER) {
@@ -95,8 +93,7 @@ impl MinilabMk2Sim {
                 match self.working.get(*param, *control) {
                     Some(value) => {
                         println!("read param {param:#04x} control {control:#04x} -> {value}");
-                        let reply = write_value_message(*param, *control, value);
-                        SimEffect::SendSysex(Sysex::try_from(reply.as_slice()).unwrap())
+                        SimEffect::SendSysex(write_value_message(*param, *control, value))
                     }
                     None => {
                         eprintln!("read of unknown param {param:#04x} control {control:#04x}");
@@ -194,7 +191,7 @@ impl SimRunner {
                     break;
                 }
                 Some(timed) = self.sysex_in.recv() => {
-                    let sysex_in = Sysex::new(timed.payload.bytes().to_vec());
+                    let sysex_in = timed.payload;
                     println!("received sysex payload: {}", sysex_in.preview());
 
                     let effect = self.sim.update(SimMsg::SysexReceived(sysex_in));
@@ -203,13 +200,8 @@ impl SimRunner {
                         SimEffect::SendSysex(sysex_out) => {
                             println!("sending sysex payload: {}", sysex_out.preview());
 
-                            match SysEx::new(sysex_out.payload()) {
-                                Ok(sysex) => {
-                                    if let Err(e) = self.out_port.send_sysex(&sysex).await {
-                                        eprintln!("MIDI send error: {e}");
-                                    }
-                                }
-                                Err(e) => eprintln!("MIDI send error: {e}"),
+                            if let Err(e) = self.out_port.send_sysex(&sysex_out).await {
+                                eprintln!("MIDI send error: {e}");
                             }
                         }
                         SimEffect::Noop => {}
@@ -246,14 +238,13 @@ mod tests {
 
     use super::*;
 
-    fn sim_request(sim: &mut MinilabMk2Sim, bytes: &[u8]) -> SimEffect {
-        let sysex = Sysex::try_from(bytes).unwrap();
+    fn sim_request(sim: &mut MinilabMk2Sim, sysex: SysEx) -> SimEffect {
         sim.update(SimMsg::SysexReceived(sysex))
     }
 
     fn expect_status(effect: SimEffect) -> DeviceStatus {
         match effect {
-            SimEffect::SendSysex(s) => DeviceStatus::try_from(s.as_bytes().as_slice()).unwrap(),
+            SimEffect::SendSysex(s) => DeviceStatus::try_from(s).unwrap(),
             SimEffect::Noop => panic!("expected SendSysex"),
         }
     }
@@ -261,7 +252,7 @@ mod tests {
     fn read_full_preset(sim: &mut MinilabMk2Sim) -> Preset {
         let mut store = ParamStore::default();
         for message in Preset::read_messages() {
-            let status = expect_status(sim_request(sim, &message));
+            let status = expect_status(sim_request(sim, message));
             store.apply(&status);
         }
         store.try_into_preset().unwrap()
@@ -271,7 +262,7 @@ mod tests {
     fn test_sim_identity_request() {
         let mut sim = MinilabMk2Sim::default();
 
-        let status = expect_status(sim_request(&mut sim, &identity_request_message()));
+        let status = expect_status(sim_request(&mut sim, identity_request_message()));
 
         match status {
             DeviceStatus::IdentityReply(reply) => assert_eq!(reply.firmware, SIM_FIRMWARE),
@@ -285,7 +276,7 @@ mod tests {
 
         let status = expect_status(sim_request(
             &mut sim,
-            &read_param_message(ParamId::Data1, ControlId::Knob1),
+            read_param_message(ParamId::Data1, ControlId::Knob1),
         ));
 
         match status {
@@ -304,13 +295,13 @@ mod tests {
 
         let effect = sim_request(
             &mut sim,
-            &write_param_message(ParamId::PadColor, ControlId::Pad3, PadColor::Purple.into()),
+            write_param_message(ParamId::PadColor, ControlId::Pad3, PadColor::Purple.into()),
         );
         assert!(matches!(effect, SimEffect::Noop));
 
         let status = expect_status(sim_request(
             &mut sim,
-            &read_param_message(ParamId::PadColor, ControlId::Pad3),
+            read_param_message(ParamId::PadColor, ControlId::Pad3),
         ));
 
         match status {
@@ -330,7 +321,7 @@ mod tests {
         mutated.pads.pads[9].color = PadColor::Cyan;
 
         for message in mutated.send_messages() {
-            let effect = sim_request(&mut sim, &message);
+            let effect = sim_request(&mut sim, message);
             assert!(matches!(effect, SimEffect::Noop));
         }
 
@@ -343,7 +334,7 @@ mod tests {
 
         let effect = sim_request(
             &mut sim,
-            &write_global_message(
+            write_global_message(
                 GlobalParamId::KnobAcceleration,
                 KnobAcceleration::Fast.into(),
             ),
@@ -352,7 +343,7 @@ mod tests {
 
         let mut store = ParamStore::default();
         for message in Global::read_messages() {
-            let status = expect_status(sim_request(&mut sim, &message));
+            let status = expect_status(sim_request(&mut sim, message));
             store.apply(&status);
         }
 
@@ -367,19 +358,19 @@ mod tests {
         let mut first = Preset::default();
         first.knobs.knobs[0].cc = 11.into();
         for message in first.send_messages() {
-            let _ = sim_request(&mut sim, &message);
+            let _ = sim_request(&mut sim, message);
         }
 
-        let _ = sim_request(&mut sim, &store_memory_message(MemorySlot::Slot2));
+        let _ = sim_request(&mut sim, store_memory_message(MemorySlot::Slot2));
 
         let mut second = Preset::default();
         second.knobs.knobs[0].cc = 22.into();
         for message in second.send_messages() {
-            let _ = sim_request(&mut sim, &message);
+            let _ = sim_request(&mut sim, message);
         }
         assert_eq!(read_full_preset(&mut sim), second);
 
-        let _ = sim_request(&mut sim, &recall_memory_message(MemorySlot::Slot2));
+        let _ = sim_request(&mut sim, recall_memory_message(MemorySlot::Slot2));
         assert_eq!(read_full_preset(&mut sim), first);
     }
 
@@ -389,7 +380,7 @@ mod tests {
 
         let status = expect_status(sim_request(
             &mut sim,
-            &read_global_message(GlobalParamId::KeyboardChannel),
+            read_global_message(GlobalParamId::KeyboardChannel),
         ));
 
         assert!(matches!(status, DeviceStatus::GlobalValue(_)));


### PR DESCRIPTION
Protocol builders now return midi_io::SysEx and parsers accept it, so editors, sims, and HIL tests pass SysEx through channels directly instead of re-framing to wire bytes and fallibly re-parsing on both the send and receive paths. The midilab::sysex::Sysex newtype and the single-variant SysexParseError are deleted; the module keeps the u7/u14 packing helpers and adds sysex(), from_header_and_body(), and a SysExPreview extension trait. midilab_io::recv_device_bytes is now the generic recv_device<T>.